### PR TITLE
Session chords reach a parked toolbar

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
@@ -124,6 +124,12 @@
     <string name="shell_tip_pause">Пауза</string>
     <string name="shell_tip_replay">Сначала</string>
     <string name="shell_tip_monitor">Мониторинг</string>
+    <string name="shell_view_terminal">Терминал</string>
+    <string name="shell_view_files">Файлы</string>
+    <string name="shell_view_monitor">Мониторинг</string>
+    <string name="shell_view_runbook">Ранбук</string>
+    <string name="shell_view_player">Запись</string>
+    <string name="shell_view_desktop">Удалённый рабочий стол</string>
     <string name="shell_tip_disconnect">Отключить</string>
     <string name="shell_no_hosts_yet">Пока нет хостов</string>
     <string name="shell_add_first_host">Добавьте подключение, и оно появится здесь.</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
@@ -124,6 +124,12 @@
     <string name="shell_tip_pause">暂停</string>
     <string name="shell_tip_replay">重播</string>
     <string name="shell_tip_monitor">监控</string>
+    <string name="shell_view_terminal">终端</string>
+    <string name="shell_view_files">文件</string>
+    <string name="shell_view_monitor">监控</string>
+    <string name="shell_view_runbook">运行手册</string>
+    <string name="shell_view_player">录制</string>
+    <string name="shell_view_desktop">远程桌面</string>
     <string name="shell_tip_disconnect">断开连接</string>
     <string name="shell_no_hosts_yet">还没有主机</string>
     <string name="shell_add_first_host">添加连接后会显示在这里。</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shell.xml
@@ -124,6 +124,12 @@
     <string name="shell_tip_pause">Pause</string>
     <string name="shell_tip_replay">Replay</string>
     <string name="shell_tip_monitor">Monitoring</string>
+    <string name="shell_view_terminal">Terminal</string>
+    <string name="shell_view_files">Files</string>
+    <string name="shell_view_monitor">Monitoring</string>
+    <string name="shell_view_runbook">Runbook</string>
+    <string name="shell_view_player">Recording</string>
+    <string name="shell_view_desktop">Remote desktop</string>
     <string name="shell_tip_disconnect">Disconnect</string>
     <string name="shell_no_hosts_yet">No hosts yet</string>
     <string name="shell_add_first_host">Add a connection to see it here.</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
@@ -14,6 +14,8 @@ import app.skerry.shared.vault.SecurityLog
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultBiometrics
 import app.skerry.ui.ai.AiAssistantController
+import app.skerry.ui.terminal.CastOpenResult
+import app.skerry.ui.terminal.openCastFile
 import app.skerry.ui.host.HostManagerController
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.known.KnownHostsController
@@ -333,3 +335,12 @@ val LocalAi: ProvidableCompositionLocal<AiAssistantController?> = staticComposit
  * vault gate (the toggle is a synced SETTINGS record in the vault).
  */
 val LocalUpdates: ProvidableCompositionLocal<UpdateNoticeController?> = staticCompositionLocalOf { null }
+
+/**
+ * How the `.cast` player asks the user for a file. The default is the real picker; a test replaces
+ * it, because the driver behind it ([app.skerry.ui.terminal.CastOpenDriver]) is composed by the
+ * window chrome and a native file dialog cannot be answered from a test — without this seam the
+ * whole playback path is reachable only by hand.
+ */
+val LocalCastPicker: ProvidableCompositionLocal<suspend () -> CastOpenResult> =
+    staticCompositionLocalOf { ::openCastFile }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -31,9 +31,8 @@ import app.skerry.ui.terminal.TerminalCursorStyle
 import app.skerry.ui.terminal.TerminalFont
 import app.skerry.ui.terminal.TerminalTheme
 import app.skerry.ui.terminal.TerminalThemes
+import app.skerry.ui.terminal.ToolbarRequest
 import app.skerry.ui.theme.ThemeMode
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 
 /** Left rail / top-level views of the layout. */
 enum class DesktopView { Terminal, Sftp, Monitor, Ports, Snippets, Runbooks, Vault, Known, Teams }
@@ -474,8 +473,9 @@ class DesktopDesignState(
     }
 
     /**
-     * A focus request the assistant's input has not taken yet. A flag rather than the one-shot
-     * [SharedFlow] the always-mounted AI bar used: the chord usually fires while the panel is closed,
+     * A focus request the assistant's input has not taken yet. A flag rather than a one-shot signal,
+     * for the reason [app.skerry.ui.terminal.ToolbarRequest] spells out: the chord usually fires
+     * while the panel is closed,
      * so there is no collector at that moment and an emitted event would simply be dropped — the
      * panel would open with the caret still in the terminal. The ask row clears it via
      * [consumeAssistantFocus] once it has the focus, so a later remount can't take it retroactively.
@@ -485,28 +485,23 @@ class DesktopDesignState(
     /** The ask row took the pending focus request (see [assistantFocusPending]). */
     fun consumeAssistantFocus() { assistantFocusPending = false }
 
-    // Hotkeys for the toolbar buttons that own their own state (snippet palette popup, recording
-    // toggle, file picker). Same one-shot signal as the AI bar above rather than a flag on the
-    // state: a boolean would have to be reset by the button and could re-fire on recomposition.
-    private val _snippetPaletteRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val snippetPaletteRequests: SharedFlow<Unit> = _snippetPaletteRequests
-    fun requestSnippetPalette() { _snippetPaletteRequests.tryEmit(Unit) }
+    // The hotkeys and the overflow menu for the toolbar buttons that own their own state (the two
+    // palettes, the recorder, the share panel). Flags rather than one-shot signals: the chord fires
+    // while the button may be out of composition entirely — see [ToolbarRequest].
+    val snippetPalette = ToolbarRequest()
+    val recordingToggle = ToolbarRequest()
+    val sharePanel = ToolbarRequest()
+    val runbookPalette = ToolbarRequest()
 
-    private val _recordingToggleRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val recordingToggleRequests: SharedFlow<Unit> = _recordingToggleRequests
-    fun requestRecordingToggle() { _recordingToggleRequests.tryEmit(Unit) }
+    /**
+     * Open a `.cast` in the player. Read by a driver in the window chrome rather than by the
+     * toolbar button, because ⌘⇧P is the one chord of the set that needs no session: it has to work
+     * over a remote desktop and over an already-open recording, neither of which draws a toolbar.
+     */
+    val castOpen = ToolbarRequest()
 
-    private val _sharePanelRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val sharePanelRequests: SharedFlow<Unit> = _sharePanelRequests
-    fun requestSharePanel() { _sharePanelRequests.tryEmit(Unit) }
-
-    private val _runbookPaletteRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val runbookPaletteRequests: SharedFlow<Unit> = _runbookPaletteRequests
-    fun requestRunbookPalette() { _runbookPaletteRequests.tryEmit(Unit) }
-
-    private val _castOpenRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val castOpenRequests: SharedFlow<Unit> = _castOpenRequests
-    fun requestCastOpen() { _castOpenRequests.tryEmit(Unit) }
+    /** A file picker for [castOpen] is already up — a second dialog on top of it hangs the app. */
+    var castOpening: Boolean by mutableStateOf(false)
 
     /** Whether folder [name] is collapsed (its host list hidden). */
     override fun isGroupCollapsed(name: String): Boolean = name in collapsedGroups

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
@@ -61,6 +61,8 @@ import app.skerry.ui.snippet.SnippetManager
 import app.skerry.ui.snippet.SnippetRunDialog
 import app.skerry.ui.snippet.maskSecrets
 import app.skerry.ui.terminal.CommandPalette
+import app.skerry.ui.terminal.CastOpenDriver
+import app.skerry.ui.terminal.CastOpenResult
 import app.skerry.ui.terminal.CastPlayerOverlay
 import app.skerry.ui.terminal.recordingOutcomeMessage
 import app.skerry.ui.vault.VaultGate
@@ -98,6 +100,7 @@ import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalHostClickConnectMode
 import app.skerry.ui.app.LocalRunSnippetOnHost
 import app.skerry.ui.app.LocalRunbookRunner
+import app.skerry.ui.design.spaceLabel
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.app.LocalTerminalHistory
@@ -393,6 +396,24 @@ internal fun DesktopChrome(
         )
         Box(Modifier.fillMaxSize().background(Skerry.colors.bg).onPreviewKeyEvent(onRootKey)) {
             DesktopShell(state, onLockWithTunnels, windowChrome, bare = bareDesktop)
+            // The `.cast` picker, driven here rather than from the toolbar button that raises it:
+            // ⌘⇧P needs no session, so it has to answer over a remote desktop and over an already
+            // open recording — neither of which draws a toolbar (issue #337).
+            val playerTabTitle = stringResource(Res.string.term_player_title)
+            CastOpenDriver(state) { result ->
+                if (result is CastOpenResult.Loaded && sessions != null) {
+                    state.clearOverlay()
+                    // The file name labels the tab: it says "recording", and two recordings of the
+                    // same host stay apart (their in-file titles are both just the host name).
+                    // The name comes off a file someone else may have named, and a tab title is
+                    // also the accessible name of that tab's close button — the same reason the OSC
+                    // title is stripped in the emulator (a bidi override makes one chip read as
+                    // another). Through [spaceLabel], the rule every peer-named row already uses.
+                    sessions.openPlayer(spaceLabel(result.fileName, playerTabTitle), result.cast)
+                } else {
+                    state.showCast(result)
+                }
+            }
             // Mock/preview only: with live sessions a recording opens in its own tab (SessionView.Player),
             // and this state is never set. Esc (via ModalScrim) closes the overlay.
             state.castRecording?.let { cast -> CastPlayerOverlay(cast, onDismiss = state::closeCast) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopSessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopSessionActions.kt
@@ -122,24 +122,23 @@ internal fun runDesktopShortcut(
         }
         DesktopShortcut.Lock -> onLock()
         DesktopShortcut.Broadcast -> state.openBroadcast()
-        // These three live in toolbar buttons that own their state; the shortcut nudges them, and
-        // asks for nothing where there is no connected pane to nudge for — the button would refuse,
-        // and a request nobody acts on is a chord spent for nothing. Not airtight: with the tab
-        // switched to Files, Monitor or a runbook the pane is still connected but the terminal
-        // toolbar is out of composition, so the request is emitted into a replay-0 flow and
-        // dropped. Closing that needs the request to become a flag the button reads when it does
-        // compose, which is a change of its own — and playback is not exempt from it but the worst
-        // case of it: its button needs no session, yet it lives in the same toolbar, so ⌘⇧P is
-        // dropped over a remote desktop and over an open recording too.
+        // These two live in toolbar buttons that own their state; the shortcut nudges them, and asks
+        // for nothing where there is no connected pane to nudge for — the button would refuse, and a
+        // request nobody acts on is a chord spent for nothing. The ask outlives the frame it was
+        // made in ([ToolbarRequest]), so the button reads it when it composes rather than having to
+        // be composed already — which is why bringing that view up on the same line works at all.
         DesktopShortcut.SnippetPalette -> {
             if (!consumesSessionChord(sessions)) return false
-            if (actsOnSessionChord(sessions)) state.requestSnippetPalette()
+            if (actsOnSessionChord(sessions)) { raiseToolbar(state, sessions); state.snippetPalette.raise() }
         }
         DesktopShortcut.ToggleRecording -> {
             if (!consumesSessionChord(sessions)) return false
-            if (actsOnSessionChord(sessions)) state.requestRecordingToggle()
+            if (actsOnSessionChord(sessions)) { raiseToolbar(state, sessions); state.recordingToggle.raise() }
         }
-        DesktopShortcut.PlayRecording -> state.requestCastOpen()
+        // Playback is the one of the set that needs no session, and its picker is driven by the
+        // window chrome rather than by the toolbar — so it works over a remote desktop and over an
+        // already-open recording, where there is no toolbar to bring up.
+        DesktopShortcut.PlayRecording -> state.castOpen.raise()
         // Only over a live terminal: the palette inserts into it, so with nothing to insert into the
         // key falls through (to the snippet hotkey) instead of opening a dead-end overlay — and over
         // a remote desktop, where it cannot fall through, it opens nothing at all.
@@ -165,6 +164,24 @@ internal fun runDesktopShortcut(
         }
     }
     return true
+}
+
+/**
+ * Bring the terminal toolbar on screen for a chord that nudges one of its buttons. Those buttons are
+ * drawn by the terminal view alone, so over the file panel, the monitor or a runbook run the ask
+ * would otherwise wait for a toolbar nobody is looking at — the palette would open on the next
+ * switch back instead of now. Find, the command palette and the assistant do the same.
+ *
+ * A recording is not in that list and cannot be: a player tab's pane never reaches Connected, so
+ * [actsOnSessionChord] is already false there and `setActiveView` refuses such a tab outright.
+ * Playback is the one chord of the set that still answers there, and it does so without a toolbar.
+ *
+ * Only ever reached with a connected pane in the active tab ([actsOnSessionChord]), which is what
+ * makes the switch total: a remote-desktop or player tab has no connected pane and never gets here.
+ */
+private fun raiseToolbar(state: DesktopDesignState, sessions: SessionsController?) {
+    state.clearOverlay()
+    sessions?.setActiveView(SessionView.Terminal)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Viewport.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Viewport.kt
@@ -9,6 +9,14 @@ import app.skerry.ui.session.SessionView
 import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.DesktopView
 import app.skerry.ui.app.UiTags
+import app.skerry.ui.design.StatusAnnouncer
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.shell_view_desktop
+import app.skerry.ui.generated.resources.shell_view_files
+import app.skerry.ui.generated.resources.shell_view_monitor
+import app.skerry.ui.generated.resources.shell_view_player
+import app.skerry.ui.generated.resources.shell_view_runbook
+import app.skerry.ui.generated.resources.shell_view_terminal
 import app.skerry.ui.host.HostSection
 import app.skerry.ui.known.KnownHostsView
 import app.skerry.ui.app.LocalSessions
@@ -25,6 +33,7 @@ import app.skerry.ui.vault.VaultView
 import app.skerry.ui.vnc.RemoteDesktopsView
 import app.skerry.ui.app.asSessionView
 import app.skerry.ui.app.workAreaSection
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * Switches the main content area. App-level views (Vault/Known/Teams/Snippets) render over
@@ -70,6 +79,12 @@ fun Viewport(state: DesktopDesignState) {
         HostSection.Terminal -> {
             // activeTerminal, not active: a remote-desktop tab renders in the branch above.
             val view = sessions?.activeTerminal?.view ?: state.view.asSessionView()
+            // A chord can swap what the work area shows without touching focus — the snippet and
+            // record shortcuts bring the terminal forward from the file panel, and the runbook
+            // dialog jumps to the run. A sighted user sees the pane change; without this the screen
+            // reader says nothing and the next keystroke goes somewhere the user was not told about.
+            // Composed above the `when` so it survives the swap it describes (see [StatusAnnouncer]).
+            StatusAnnouncer(sessionViewName(view))
             Box(Modifier.fillMaxSize().testTag(UiTags.screen(view))) {
                 when (view) {
                     SessionView.Terminal -> TerminalView(state)
@@ -84,3 +99,16 @@ fun Viewport(state: DesktopDesignState) {
         }
     }
 }
+
+/** What the work area is showing, for the live region above it. */
+@Composable
+private fun sessionViewName(view: SessionView): String = stringResource(
+    when (view) {
+        SessionView.Terminal -> Res.string.shell_view_terminal
+        SessionView.Sftp -> Res.string.shell_view_files
+        SessionView.Monitor -> Res.string.shell_view_monitor
+        SessionView.Runbook -> Res.string.shell_view_runbook
+        SessionView.Player -> Res.string.shell_view_player
+        SessionView.Vnc -> Res.string.shell_view_desktop
+    },
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPalette.kt
@@ -41,7 +41,6 @@ import app.skerry.ui.app.LocalRunbooks
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.design.fieldName
-import kotlinx.coroutines.flow.SharedFlow
 import app.skerry.ui.design.CloseWhenUnavailable
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
@@ -61,6 +60,8 @@ import app.skerry.ui.session.Session
 import app.skerry.ui.session.SessionView
 import app.skerry.ui.terminal.ToolbarAction
 import app.skerry.ui.terminal.toolbarActionEnabled
+import app.skerry.ui.terminal.OnToolbarRequest
+import app.skerry.ui.terminal.ToolbarRequest
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
@@ -74,7 +75,7 @@ import org.jetbrains.compose.resources.stringResource
  * comes first, and the progress panel takes over from there.
  */
 @Composable
-fun RunbookPaletteButton(active: Session?, requests: SharedFlow<Unit>? = null) {
+fun RunbookPaletteButton(active: Session?, request: ToolbarRequest? = null) {
     val manager = LocalRunbooks.current
     val runner = LocalRunbookRunner.current
     val terminal = (active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
@@ -84,8 +85,8 @@ fun RunbookPaletteButton(active: Session?, requests: SharedFlow<Unit>? = null) {
     // palette without this button having to be on screen (it may be parked out of a narrow toolbar).
     // The same condition the button carries, not half of it: a request that arrives mid-run would
     // otherwise set the flag for a popup the render guard then drops without a word.
-    LaunchedEffect(requests, terminal) {
-        requests?.collect { if (terminal != null && runner?.let { !it.active && it.pending == null } == true) open = true }
+    OnToolbarRequest(request) {
+        if (terminal != null && runner?.let { !it.active && it.pending == null } == true) open = true
     }
     if (manager == null || runner == null) return
     // While this tab is part of a run, the icon is the way back to the run screen rather than a

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/share/ShareSessionButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/share/ShareSessionButton.kt
@@ -61,8 +61,9 @@ import app.skerry.ui.generated.resources.share_starting
 import app.skerry.ui.generated.resources.share_title
 import app.skerry.ui.generated.resources.share_viewers
 import app.skerry.ui.session.Session
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
+import app.skerry.ui.terminal.OnToolbarRequest
+import app.skerry.ui.terminal.ToolbarRequest
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
 
@@ -87,9 +88,9 @@ fun ShareSessionButton(
     session: Session?,
     controller: SessionShareController?,
     teams: List<Pair<String, String>>,
-    // Fired by the overflow menu when the row is too narrow to show the button itself; the button
-    // owns the panel, so the menu asks it to open rather than duplicating it.
-    requests: SharedFlow<Unit>? = null,
+    // Raised by the overflow menu when the row is too narrow to show the button itself; the button
+    // owns the panel, so the ask goes to it rather than duplicating it.
+    request: ToolbarRequest? = null,
 ) {
     // Keyed on the session, like the other toolbar popups: switching tabs must not leave the panel
     // open over a different session's toolbar.
@@ -101,20 +102,32 @@ fun ShareSessionButton(
     LaunchedEffect(live, terminal?.cols, terminal?.rows) {
         if (live) controller?.announceGeometry()
     }
-    // `live` is a key too, not just a captured value: a stream stopped without the terminal changing
-    // would otherwise leave this collector opening the panel on a share that is already over.
-    LaunchedEffect(requests, terminal, live) { requests?.collect { if (live || terminal != null) open = true } }
     // A pane that is watching someone else's session gets the viewer's panel behind the same button:
     // its only control is asking the host for permission to type. Relaying a colleague's stream on
     // to a third team is never offered — the pane's own flag decides that, not the viewer registry,
     // which is keyed by pane id and cleared the moment the watched session ends.
     val watched = LocalSharedSessions.current?.watching?.get(session?.id)
     if (watched != null) {
-        WatchedSessionButton(watched, session?.subtitle.orEmpty(), requests)
+        // Ahead of this button's own reader: one request has one taker, and the panel the viewer
+        // gets is the one behind the button actually on screen.
+        WatchedSessionButton(watched, session?.subtitle.orEmpty(), request)
         return
     }
-    if (session?.controller?.isWatched == true) return
-    if (controller == null) return
+    if (session?.controller?.isWatched == true || controller == null) {
+        // Taken and dropped, not left pending. There is no button here to open a panel on, and an ask
+        // that keeps waiting is one the overflow row can raise with sync disconnected — it would then
+        // fire on whichever session is active when sync connects, putting the streaming-consent panel
+        // on screen unasked. Same rule the panel's own asks follow: one frame, one taker.
+        OnToolbarRequest(request) {}
+        return
+    }
+    // Below every early return, not above them: a reader that runs in a composition which then
+    // bails takes the ask and parks `open` in a slot nobody draws — which is why the bail-out above
+    // reads it with an empty action instead of letting this one run there.
+    //
+    // A stream stopped without the terminal changing must not leave a request opening the panel on
+    // a share that is already over — [live] is read here rather than captured at subscription.
+    OnToolbarRequest(request) { if (live || terminal != null) open = true }
     Box {
         // Nothing to share without a live session, but a stream already running keeps the control
         // that stops it. Disabled rather than dimmed-and-live: the guard used to sit in the handler,
@@ -306,13 +319,13 @@ private const val MAX_SHOWN_VIEWERS = 4
 private fun WatchedSessionButton(
     viewer: app.skerry.shared.share.SharedSessionViewer,
     hostAccount: String,
-    requests: SharedFlow<Unit>?,
+    request: ToolbarRequest?,
 ) {
     var open by remember(viewer) { mutableStateOf(false) }
     val granted by viewer.controlGranted.collectAsState()
     var asked by remember(viewer) { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
-    LaunchedEffect(requests) { requests?.collect { open = true } }
+    OnToolbarRequest(request) { open = true }
     Box {
         IconBtn(
             name = if (granted) "keyboard" else "visibility",

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/PlayRecordingButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/PlayRecordingButton.kt
@@ -1,53 +1,72 @@
 package app.skerry.ui.terminal
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
+import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.app.LocalCastPicker
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shell_tip_play
 import org.jetbrains.compose.resources.stringResource
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 
 /**
- * Toolbar button that opens a `.cast` file and hands the result to [onOpened] (which shows the
- * player or the "not a recording" notice).
+ * Toolbar button that opens a `.cast` file. Unlike the palettes and the recorder beside it, it owns
+ * nothing: the picker runs in [CastOpenDriver], which is composed by the window chrome and is
+ * therefore reachable from anywhere. ⌘⇧P needs no session, so it has to work over a remote desktop
+ * and over an already-open recording — neither of which draws this toolbar at all.
  *
  * While the picker and the parse are in flight the button is inert: a second file dialog on top of
- * the first is the kind of thing that hangs a desktop app.
+ * the first is the kind of thing that hangs a desktop app. Disabled rather than merely tinted, the
+ * same rule the rest of the toolbar follows.
  */
 @Composable
-fun PlayRecordingButton(requests: SharedFlow<Unit>? = null, onOpened: (CastOpenResult) -> Unit) {
+fun PlayRecordingButton(state: DesktopDesignState) {
+    IconBtn(
+        "play_circle",
+        onClick = { state.castOpen.raise() },
+        tooltip = stringResource(Res.string.shell_tip_play),
+        // Through the shared rule, not a second copy of it: the overflow menu row draws itself from
+        // the same call, and a menu entry that fires a request the driver then drops is the dead
+        // press the buttons themselves stopped making.
+        enabled = toolbarActionEnabled(ToolbarAction.Play, active = null, playerBusy = state.castOpening),
+    )
+}
+
+/**
+ * Runs the file picker behind [DesktopDesignState.castOpen] and hands the result to [onOpened]
+ * (which shows the player or the "not a recording" notice).
+ *
+ * Composed once, by the window chrome: the button that raises the request may be parked out of a
+ * narrow toolbar, off-screen behind another view, or absent entirely, and the ask must still be
+ * answered on the frame it arrives.
+ */
+@Composable
+fun CastOpenDriver(state: DesktopDesignState, onOpened: (CastOpenResult) -> Unit) {
     val scope = rememberCoroutineScope()
-    var opening by remember { mutableStateOf(false) }
-    val open = {
-        if (!opening) {
-            opening = true
+    // The picker comes from the composition rather than being called directly, so a test can answer
+    // it: a native file dialog cannot be driven from one, and without the seam this whole path —
+    // the chord, the button and the overflow row alike — is reachable only by hand.
+    val pick = LocalCastPicker.current
+    // The flag is set during composition and cleared by the coroutine's `finally`, so a disposal
+    // between the two — the vault locking swaps this whole tree out — cancels the job before its body
+    // runs and the `finally` never happens. The state outlives the lock, so Play would stay disabled
+    // for the rest of the process. This gives the flag and its clear one lifetime.
+    DisposableEffect(Unit) { onDispose { state.castOpening = false } }
+    OnToolbarRequest(state.castOpen) {
+        if (!state.castOpening) {
+            state.castOpening = true
             scope.launch {
+                // Nothing here throws today (both the read and the parse answer with a result rather
+                // than an exception), and the `finally` is what keeps that from becoming a button
+                // stuck inert if one day it does.
                 try {
-                    onOpened(openCastFile())
+                    onOpened(pick())
                 } finally {
-                    opening = false
+                    state.castOpening = false
                 }
             }
         }
     }
-    val currentOpen by rememberUpdatedState(open)
-    // Hotkey channel (⌘P / Ctrl+Shift+P) — same action as the click.
-    LaunchedEffect(requests) { requests?.collect { currentOpen() } }
-    // Disabled rather than merely tinted while a picker is up: the same rule the rest of the
-    // toolbar follows, and it draws the faint tint by itself. The guard inside [open] stays — the
-    // hotkey reaches this button whether or not it is clickable.
-    IconBtn(
-        "play_circle",
-        onClick = { open() },
-        tooltip = stringResource(Res.string.shell_tip_play),
-        enabled = !opening,
-    )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
@@ -1,10 +1,7 @@
 package app.skerry.ui.terminal
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.getValue
 import app.skerry.shared.terminal.castFileName
 import app.skerry.shared.terminal.recordingStamp
 import app.skerry.ui.design.IconBtn
@@ -16,7 +13,6 @@ import app.skerry.ui.session.Session
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.vault.ExportOutcome
 import app.skerry.ui.vault.exportFileGuarded
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import app.skerry.ui.theme.Skerry
 
@@ -27,13 +23,13 @@ import app.skerry.ui.theme.Skerry
  * Nothing is written until the user picks a file: a recording holds whatever the server printed, so
  * it must not land on disk as a side effect of clicking a toolbar button.
  *
- * [requests] is the hotkey channel (⌘R / Ctrl+Shift+R): the shell can't toggle recording itself,
+ * [request] is the hotkey channel (⌘R / Ctrl+Shift+R): the shell can't toggle recording itself,
  * because start/stop lives on the terminal state this button holds.
  */
 @Composable
 fun RecordSessionButton(
     session: Session?,
-    requests: SharedFlow<Unit>? = null,
+    request: ToolbarRequest? = null,
     /**
      * A recording of a catalog host was saved: `(hostId, wall-clock seconds)`. Reported to the team
      * that host is shared with, if any (see [app.skerry.ui.teams.TeamsCoordinator.reportSessionRecorded]).
@@ -75,10 +71,8 @@ fun RecordSessionButton(
             }
             Unit
         }
-    // The hotkey does exactly what a click does. rememberUpdatedState so a collector started for an
-    // earlier session doesn't keep toggling a terminal that is no longer on screen.
-    val currentToggle by rememberUpdatedState(toggle)
-    LaunchedEffect(requests) { requests?.collect { currentToggle() } }
+    // The hotkey does exactly what a click does.
+    OnToolbarRequest(request) { toggle() }
     IconBtn(
         name = if (recording) "stop_circle" else "radio_button_checked",
         tint = if (recording) Skerry.colors.sunset else Skerry.colors.dim,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SessionActions.kt
@@ -44,7 +44,6 @@ import app.skerry.ui.generated.resources.shell_tip_play
 import app.skerry.ui.generated.resources.shell_tip_record
 import app.skerry.ui.generated.resources.shell_tip_snippets
 import app.skerry.ui.generated.resources.shell_tip_sync_panes
-import app.skerry.ui.generated.resources.term_player_title
 import app.skerry.ui.runbook.RunbookPaletteButton
 import app.skerry.ui.session.Session
 import app.skerry.ui.session.SessionView
@@ -91,26 +90,28 @@ internal enum class ToolbarAction(val group: ToolbarGroup, val needsSession: Boo
  * rule that only exists inside one is a rule no test can enumerate.
  */
 @Composable
-internal fun toolbarActionEnabled(action: ToolbarAction, active: Session?): Boolean {
+internal fun toolbarActionEnabled(action: ToolbarAction, active: Session?, playerBusy: Boolean = false): Boolean {
     val runner = LocalRunbookRunner.current
     return toolbarActionEnabled(
         action,
         hasTerminal = (active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal != null,
         runnerIdle = runner != null && !runner.active && runner.pending == null,
         shareLive = LocalSessionShare.current?.state is ShareUiState.Live,
+        playerBusy = playerBusy,
     )
 }
 
 /**
  * The rule behind [toolbarActionEnabled], over the three facts the composition supplies:
  * [hasTerminal] — the pane in focus is connected, [runnerIdle] — no runbook is mid-run, and
- * [shareLive] — a stream is on the air right now.
+ * [shareLive] — a stream is on the air right now, and [playerBusy] — a `.cast` picker is already up.
  */
 internal fun toolbarActionEnabled(
     action: ToolbarAction,
     hasTerminal: Boolean,
     runnerIdle: Boolean,
     shareLive: Boolean,
+    playerBusy: Boolean = false,
 ): Boolean = when (action) {
     // Nothing to send into without a connected session.
     ToolbarAction.Snippets, ToolbarAction.Record -> hasTerminal
@@ -119,7 +120,11 @@ internal fun toolbarActionEnabled(
     // Nothing to share without a connected session — but a stream already running keeps the control
     // that stops it, and on a narrow toolbar the menu row is the only copy of that control left.
     ToolbarAction.Share -> hasTerminal || shareLive
-    ToolbarAction.Files, ToolbarAction.Monitor, ToolbarAction.Play -> true
+    // A recording is watched, not run, so playback needs no session at all — only a picker that is
+    // not already up. The second file dialog on top of the first is what hangs the app, and the
+    // menu row has to refuse it as plainly as the button does.
+    ToolbarAction.Play -> !playerBusy
+    ToolbarAction.Files, ToolbarAction.Monitor -> true
 }
 
 /**
@@ -247,18 +252,6 @@ internal fun RowScope.SessionActions(
             state.showView(DesktopView.Monitor)
         }
     }
-    val playerTabTitle = stringResource(Res.string.term_player_title)
-    val onCastOpened: (CastOpenResult) -> Unit = { result ->
-        if (result is CastOpenResult.Loaded && sessions != null) {
-            state.clearOverlay()
-            // The file name labels the tab: it says "recording", and two recordings of the same
-            // host stay apart (their in-file titles are both just the host name).
-            sessions.openPlayer(result.fileName.ifBlank { playerTabTitle }, result.cast)
-        } else {
-            state.showCast(result)
-        }
-    }
-
     // Group 1 — the workspace: what the tab holds and which of its views is on screen.
     // Synchronized input: typing in one pane reaches every connected pane of this tab. Lit while on,
     // since it changes where every keystroke goes. Shown only once the tab is actually split — with
@@ -300,19 +293,19 @@ internal fun RowScope.SessionActions(
     // Group 2 — what can be sent into the session running there.
     ActionGroupSeparator(shown = groupDrawn(ToolbarGroup.Workspace) && groupDrawn(ToolbarGroup.Session))
     // Quick snippet launch into the active session without leaving for the Snippets section.
-    if (drawn(ToolbarAction.Snippets)) SnippetPaletteButton(active, state.snippetPaletteRequests)
+    if (drawn(ToolbarAction.Snippets)) SnippetPaletteButton(active, state.snippetPalette)
     // Same idea one size up: start a saved procedure here instead of going to its section.
-    if (drawn(ToolbarAction.Runbook)) RunbookPaletteButton(active, state.runbookPaletteRequests)
+    if (drawn(ToolbarAction.Runbook)) RunbookPaletteButton(active, state.runbookPalette)
     // Streams this session to a team over the sync relay (viewers watch; the host decides whether
     // they may type).
     if (drawn(ToolbarAction.Share)) {
-        ShareSessionButton(active, LocalSessionShare.current, shareableTeams(), state.sharePanelRequests)
+        ShareSessionButton(active, LocalSessionShare.current, shareableTeams(), state.sharePanel)
     }
     // Asciinema recording of this session; the stop click offers a Save-As for the .cast.
     if (drawn(ToolbarAction.Record)) {
         RecordSessionButton(
             active,
-            state.recordingToggleRequests,
+            state.recordingToggle,
             onSaved = { hostId, seconds -> teams?.reportSessionRecorded(hostId, seconds) },
         ) { state.showRecordingNotice(it) }
     }
@@ -325,7 +318,7 @@ internal fun RowScope.SessionActions(
     // sits here rather than behind a connected-only guard. Live mode opens the recording in its own
     // tab, so the shells stay reachable while it plays; the mock path (no session manager) has no
     // tabs and falls back to the overlay.
-    if (drawn(ToolbarAction.Play)) PlayRecordingButton(state.castOpenRequests, onCastOpened)
+    if (drawn(ToolbarAction.Play)) PlayRecordingButton(state)
     // Opens the assistant beside the terminal. Lit while it is open, like the info toggle; absent
     // entirely when AI is off for this host or globally, so a host that opted out shows no AI
     // affordance at all.
@@ -342,7 +335,7 @@ internal fun RowScope.SessionActions(
             hidden,
             state,
             tabKey = tab?.id,
-            enabled = { toolbarActionEnabled(it, active) },
+            enabled = { toolbarActionEnabled(it, active, playerBusy = state.castOpening) },
             onOpenSftp = openSftp,
             onOpenMonitor = openMonitor,
         )
@@ -358,21 +351,21 @@ internal fun RowScope.SessionActions(
         )
     }
     // Parked out of sight, still in composition: these buttons own the palettes, the recorder and
-    // the file pickers behind them, and dropping them from the tree would take that state with them
-    // — the overflow menu drives them through their request signals instead.
+    // the share panel behind them, and dropping them from the tree would take that state with them
+    // — the overflow menu drives them through their requests instead. The player is not here: its
+    // picker is driven by the window chrome ([CastOpenDriver]), so its button owns nothing.
     Box(Modifier.size(0.dp).clipToBounds()) {
-        if (ToolbarAction.Snippets in hidden) SnippetPaletteButton(active, state.snippetPaletteRequests)
-        if (ToolbarAction.Runbook in hidden) RunbookPaletteButton(active, state.runbookPaletteRequests)
+        if (ToolbarAction.Snippets in hidden) SnippetPaletteButton(active, state.snippetPalette)
+        if (ToolbarAction.Runbook in hidden) RunbookPaletteButton(active, state.runbookPalette)
         if (ToolbarAction.Record in hidden) {
             RecordSessionButton(
                 active,
-                state.recordingToggleRequests,
+                state.recordingToggle,
                 onSaved = { hostId, seconds -> teams?.reportSessionRecorded(hostId, seconds) },
             ) { state.showRecordingNotice(it) }
         }
-        if (ToolbarAction.Play in hidden) PlayRecordingButton(state.castOpenRequests, onCastOpened)
         if (ToolbarAction.Share in hidden) {
-            ShareSessionButton(active, LocalSessionShare.current, shareableTeams(), state.sharePanelRequests)
+            ShareSessionButton(active, LocalSessionShare.current, shareableTeams(), state.sharePanel)
         }
     }
 }
@@ -467,11 +460,11 @@ internal fun OverflowActionsButton(
                         val run: () -> Unit = when (action) {
                             ToolbarAction.Files -> onOpenSftp
                             ToolbarAction.Monitor -> onOpenMonitor
-                            ToolbarAction.Snippets -> state::requestSnippetPalette
-                            ToolbarAction.Runbook -> state::requestRunbookPalette
-                            ToolbarAction.Record -> state::requestRecordingToggle
-                            ToolbarAction.Play -> state::requestCastOpen
-                            ToolbarAction.Share -> state::requestSharePanel
+                            ToolbarAction.Snippets -> state.snippetPalette::raise
+                            ToolbarAction.Runbook -> state.runbookPalette::raise
+                            ToolbarAction.Record -> state.recordingToggle::raise
+                            ToolbarAction.Play -> state.castOpen::raise
+                            ToolbarAction.Share -> state.sharePanel::raise
                         }
                         MenuActionRow(icon = action.icon, label = stringResource(action.label), enabled = enabled(action)) {
                             open = false

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.design.fieldName
-import kotlinx.coroutines.flow.SharedFlow
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.design.CloseWhenUnavailable
 import app.skerry.ui.design.IconBtn
@@ -74,14 +73,14 @@ import app.skerry.ui.design.untrustedLabel
 // Snippet palette: quickly run a saved command in the active terminal directly from the toolbar.
 
 @Composable
-internal fun SnippetPaletteButton(active: Session?, requests: SharedFlow<Unit>? = null) {
+internal fun SnippetPaletteButton(active: Session?, request: ToolbarRequest? = null) {
     val manager = LocalSnippets.current
     val terminal = (active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
     // Keyed on active: switching tabs must not leave the palette open over a different toolbar.
     var open by remember(active) { mutableStateOf(false) }
     // Hotkey channel (⌘S / Ctrl+Shift+S). It only opens: with nothing to run into, the palette would
     // be a dead-end popup, so the key falls through to whatever else wants it.
-    LaunchedEffect(requests, terminal) { requests?.collect { if (terminal != null) open = true } }
+    OnToolbarRequest(request) { if (terminal != null) open = true }
     if (manager == null) return
     val enabled = toolbarActionEnabled(ToolbarAction.Snippets, active)
     CloseWhenUnavailable(enabled) { open = false }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -91,6 +91,18 @@ fun TerminalView(state: DesktopDesignState) {
         assistants?.takeIf { AiPolicyDecision.of(aiPolicy).aiEnabled }?.controller(session.id, aiPolicy)
     }
     val assistantVisible = state.assistantPanel && assistantController != null
+    // An ask nobody can take has to be dropped, not kept. The panel is the only reader of the focus
+    // request, and it is not composed at all when AI is off for this host — so a chord pressed there
+    // would otherwise leave the ask parked until some later tab whose host has AI on, where the
+    // input row would steal the caret from the shell the user just switched to. Same rule the
+    // toolbar's own asks follow ([app.skerry.ui.terminal.ToolbarRequest]): one frame, one taker.
+    //
+    // Keyed on the flag as well as on the panel: the chord raises both in the same frame, so an
+    // effect keyed on the panel alone would never re-run where the panel never appears — which is
+    // the one case this is here for.
+    LaunchedEffect(assistantVisible, state.assistantFocusPending) {
+        if (!assistantVisible) state.consumeAssistantFocus()
+    }
     // A closed pane's conversation is dropped with it, so closing tabs doesn't accumulate
     // controllers (and a request left in flight there is cancelled).
     val openPaneIds = sessions?.tabs?.flatMap { it.panes.map { pane -> pane.id } }?.toSet()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/ToolbarRequest.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/ToolbarRequest.kt
@@ -1,0 +1,55 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+
+/**
+ * An ask waiting for one of the toolbar buttons that own their own state — the snippet and runbook
+ * palettes, the recorder, the share panel.
+ *
+ * Held as state rather than sent as a one-shot signal, for the same reason the assistant's focus
+ * request is a flag ([app.skerry.ui.app.DesktopDesignState.assistantFocusPending]): the keyboard
+ * chord and the overflow menu both fire while the button may not be composed at all — the terminal
+ * toolbar is drawn by the terminal view, and the tab may be showing the file panel, the monitor, a
+ * runbook run or a recording. An event emitted with no collector is gone, and the chord is spent
+ * with nothing on screen to show for it.
+ *
+ * The button takes the ask the moment it composes and reads it ([OnToolbarRequest]), so a flag
+ * cannot fire twice on a later recomposition either.
+ */
+@Stable
+class ToolbarRequest {
+    /** Whether an ask is waiting for its button. */
+    var pending: Boolean by mutableStateOf(false)
+        private set
+
+    /** Ask. Asking twice before the button reads it is still one ask. */
+    fun raise() { pending = true }
+
+    /** Take the pending ask, if there is one, and clear it. */
+    fun take(): Boolean {
+        val was = pending
+        pending = false
+        return was
+    }
+}
+
+/**
+ * Runs [action] once per ask raised on [request], as soon as the button that reads it is composed.
+ *
+ * [action] runs whether or not the button can act on it — the ask is taken either way, so one the
+ * button has nothing to do with cannot linger and surprise the user on a later tab switch.
+ */
+@Composable
+fun OnToolbarRequest(request: ToolbarRequest?, action: () -> Unit) {
+    val current by rememberUpdatedState(action)
+    val pending = request?.pending == true
+    LaunchedEffect(request, pending) {
+        if (pending && request?.take() == true) current()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
@@ -19,7 +19,6 @@ import app.skerry.ui.session.SessionsController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -253,12 +252,11 @@ class DesktopShortcutsTest {
         advanceUntilIdle()
         // The half that keeps the gate honest: consuming the chord and doing nothing would satisfy
         // the refusals above and the two "consumed and nothing more" tests both.
-        val asked = recordRequests(state)
         for (chord in listOf(DesktopShortcut.SnippetPalette, DesktopShortcut.ToggleRecording, DesktopShortcut.CommandPalette)) {
             assertTrue(runDesktopShortcut(chord, state, sessions) {}, "$chord acts on a connected session")
         }
         advanceUntilIdle()
-        assertEquals(listOf("snippets", "record"), asked, "both buttons are nudged")
+        assertEquals(listOf("snippets", "record"), asked(state), "both buttons are nudged")
         assertTrue(state.commandPaletteOpen, "the palette has a terminal to insert into")
         scope.cancel()
     }
@@ -283,6 +281,34 @@ class DesktopShortcutsTest {
     }
 
     /**
+     * The three chords nudge buttons that live in the terminal toolbar, and only the terminal view
+     * draws that toolbar. Pressed over the file panel, the monitor, a runbook run or a recording the
+     * request used to be emitted into a flow nobody was collecting and lost, with the chord spent —
+     * so the chord brings that view forward first, the way find and the command palette do.
+     */
+    @Test
+    fun `the session chords bring the toolbar forward`() = runTest {
+        val (sessions, scope) = sessions()
+        sessions.open(hostId = "h", title = "h", subtitle = "u@h:22", target = testTarget, auth = auth)
+        advanceUntilIdle()
+        for (chord in listOf(DesktopShortcut.SnippetPalette, DesktopShortcut.ToggleRecording)) {
+            sessions.setActiveView(SessionView.Sftp)
+            val state = DesktopDesignState()
+            assertTrue(runDesktopShortcut(chord, state, sessions) {}, "$chord acts on a connected session")
+            assertEquals(SessionView.Terminal, sessions.active?.view, "$chord nudges a button in the terminal toolbar")
+            assertEquals(1, asked(state).size, "$chord left its ask for the button that is now composing")
+        }
+        // Playback keeps its own way in: its picker is driven by the window chrome, so the chord
+        // asks for it without moving the user off whatever they were looking at.
+        sessions.setActiveView(SessionView.Sftp)
+        val state = DesktopDesignState()
+        assertTrue(runDesktopShortcut(DesktopShortcut.PlayRecording, state, sessions) {})
+        assertEquals(SessionView.Sftp, sessions.active?.view, "playback needs no toolbar")
+        assertTrue(state.castOpen.pending, "the picker was asked for")
+        scope.cancel()
+    }
+
+    /**
      * Mock mode — no session manager at all, which is how the offscreen screenshot pipeline runs
      * the app. Nothing is connected there, so nothing is nudged; the chord is consumed all the
      * same, because that shell draws a terminal too and a fall-through would type Ctrl+Shift+S into
@@ -291,13 +317,12 @@ class DesktopShortcutsTest {
     @Test
     fun `the session chords are consumed with no session manager`() = runTest {
         val state = DesktopDesignState()
-        val asked = recordRequests(state)
         for (chord in listOf(DesktopShortcut.SnippetPalette, DesktopShortcut.ToggleRecording, DesktopShortcut.CommandPalette)) {
             assertTrue(runDesktopShortcut(chord, state, sessions = null) {}, "$chord in mock mode")
         }
         advanceUntilIdle()
         assertFalse(state.commandPaletteOpen, "there is no pane for the palette to insert into")
-        assertEquals(emptyList(), asked, "no button to nudge, so nothing is asked for")
+        assertEquals(emptyList(), asked(state), "no button to nudge, so nothing is asked for")
     }
 
     /**
@@ -314,13 +339,12 @@ class DesktopShortcutsTest {
         sessions.openVnc(hostId = "h", title = "h", subtitle = "h:5900", target = testTarget, auth = VncAuth.None)
         advanceUntilIdle()
         val state = DesktopDesignState()
-        val asked = recordRequests(state)
         for (chord in listOf(DesktopShortcut.SnippetPalette, DesktopShortcut.ToggleRecording, DesktopShortcut.CommandPalette)) {
             assertTrue(runDesktopShortcut(chord, state, sessions) {}, "$chord must not reach the guest")
         }
         advanceUntilIdle()
         assertFalse(state.commandPaletteOpen, "the command palette has no terminal to insert into here")
-        assertEquals(emptyList(), asked, "no toolbar button is composed over a desktop tab")
+        assertEquals(emptyList(), asked(state), "no toolbar button is composed over a desktop tab")
         assertTrue(
             runDesktopShortcut(DesktopShortcut.FindInTerminal, state, sessions) {},
             "find must not reach the guest either",
@@ -331,15 +355,13 @@ class DesktopShortcutsTest {
     private val auth = SshAuth.Password("pw")
 
     /**
-     * Both button-nudging request flows, in the order they fire. `replay = 0`, so the collectors
-     * have to be live before the chord runs — hence the unconfined dispatcher.
+     * Which of the two button-nudging asks are waiting to be read. Read from the state rather than
+     * collected: the ask outlives the frame it was raised in, which is the whole point of it
+     * ([app.skerry.ui.terminal.ToolbarRequest]).
      */
-    private fun TestScope.recordRequests(state: DesktopDesignState): List<String> {
-        val asked = mutableListOf<String>()
-        val live = UnconfinedTestDispatcher(testScheduler)
-        backgroundScope.launch(live) { state.snippetPaletteRequests.collect { asked += "snippets" } }
-        backgroundScope.launch(live) { state.recordingToggleRequests.collect { asked += "record" } }
-        return asked
+    private fun asked(state: DesktopDesignState): List<String> = buildList {
+        if (state.snippetPalette.pending) add("snippets")
+        if (state.recordingToggle.pending) add("record")
     }
 
     private fun TestScope.sessions(vnc: FakeVncTransport? = null): Pair<SessionsController, CoroutineScope> {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ToolbarActionEnabledTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ToolbarActionEnabledTest.kt
@@ -12,8 +12,19 @@ import kotlin.test.assertTrue
  */
 class ToolbarActionEnabledTest {
 
-    private fun enabled(action: ToolbarAction, terminal: Boolean, idle: Boolean = true, share: Boolean = false) =
-        toolbarActionEnabled(action, hasTerminal = terminal, runnerIdle = idle, shareLive = share)
+    private fun enabled(
+        action: ToolbarAction,
+        terminal: Boolean,
+        idle: Boolean = true,
+        share: Boolean = false,
+        busy: Boolean = false,
+    ) = toolbarActionEnabled(
+        action,
+        hasTerminal = terminal,
+        runnerIdle = idle,
+        shareLive = share,
+        playerBusy = busy,
+    )
 
     @Test
     fun `what needs a session to send into is off without one`() {
@@ -51,5 +62,18 @@ class ToolbarActionEnabledTest {
         for (action in listOf(ToolbarAction.Files, ToolbarAction.Monitor, ToolbarAction.Play)) {
             assertTrue(enabled(action, terminal = false), "$action with nothing connected")
         }
+    }
+
+    /**
+     * Playback is the exception to that: a recording needs no session, but it does need a picker that
+     * is not already up. A long recording parses with the window fully interactive, so both the button
+     * and the overflow row would otherwise draw lit for those seconds while every press is dropped —
+     * and a second native file dialog on top of the first hangs the app.
+     */
+    @Test
+    fun `playback is off while a picker is up`() {
+        assertFalse(enabled(ToolbarAction.Play, terminal = true, busy = true))
+        assertFalse(enabled(ToolbarAction.Play, terminal = false, busy = true))
+        assertTrue(enabled(ToolbarAction.Play, terminal = false, busy = false))
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ToolbarRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ToolbarRequestTest.kt
@@ -1,0 +1,62 @@
+package app.skerry.ui.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The ask behind the toolbar buttons that own their own state. It exists because a one-shot signal
+ * is dropped when the button is not composed (issue #337), so what matters is that it survives
+ * until a reader arrives and that exactly one reader gets it.
+ */
+class ToolbarRequestTest {
+
+    @Test
+    fun `a fresh request is not pending`() {
+        assertFalse(ToolbarRequest().pending)
+    }
+
+    @Test
+    fun `the ask waits until it is taken`() {
+        val request = ToolbarRequest()
+        request.raise()
+        assertTrue(request.pending, "the ask outlives the frame it was made in")
+        assertTrue(request.take(), "the reader gets it")
+        assertFalse(request.pending, "and it is gone")
+    }
+
+    /** A button that composes twice must not open its palette twice. */
+    @Test
+    fun `a second take gets nothing`() {
+        val request = ToolbarRequest()
+        request.raise()
+        request.take()
+        assertFalse(request.take(), "the ask is spent")
+    }
+
+    /** Holding the chord down is one ask, not a queue that fires again on the next tab switch. */
+    @Test
+    fun `raising twice before a take is still one ask`() {
+        val request = ToolbarRequest()
+        request.raise()
+        request.raise()
+        assertTrue(request.take())
+        assertFalse(request.take(), "the second raise did not queue a second ask")
+    }
+
+    @Test
+    fun `taking nothing reports nothing`() {
+        assertFalse(ToolbarRequest().take())
+    }
+
+    /** Separate buttons hold separate asks — one chord must not open the palette beside it. */
+    @Test
+    fun `requests are independent`() {
+        val snippets = ToolbarRequest()
+        val runbooks = ToolbarRequest()
+        snippets.raise()
+        assertFalse(runbooks.pending)
+        assertFalse(runbooks.take())
+        assertTrue(snippets.take())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
@@ -46,7 +46,13 @@ import androidx.compose.ui.test.runDesktopComposeUiTest
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import app.skerry.ui.AppDependencies
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.shell_tip_files
+import app.skerry.ui.generated.resources.shell_tip_record
+import app.skerry.ui.generated.resources.shell_tip_snippets
 import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.app.LocalCastPicker
+import app.skerry.ui.terminal.CastOpenResult
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.app.UiTags
 import app.skerry.ui.ai.AiAssistantController
@@ -168,6 +174,9 @@ internal fun runDesktopShell(
     // The window's own focus, for the tests about who owns the keyboard when it comes and goes. The
     // test scene's own [WindowInfo] is hardcoded focused, so there is no other way to drive it.
     windowInfo: WindowInfo? = null,
+    // What "Play a recording" answers with. null leaves the real file dialog in place, which no test
+    // can drive — a test that exercises playback has to supply its own.
+    castPicker: (suspend () -> CastOpenResult)? = null,
     body: ComposeUiTest.(DesktopShell) -> Unit,
 ) = runDesktopComposeUiTest(width = windowWidth) {
     val keyGenerator = BouncyCastleSshKeyGenerator()
@@ -192,6 +201,7 @@ internal fun runDesktopShell(
         setContent {
             CaptureFocusManager { focusManager = it }
             WithWindowInfo(windowInfo) {
+            WithCastPicker(castPicker) {
             SkerryTheme {
                 // A live AI controller only so the settings panel offers its AI tab: without one the
                 // tab is hidden, and a walk over SETTINGS_NAV would silently skip an entry.
@@ -210,6 +220,7 @@ internal fun runDesktopShell(
                         windowChrome = windowChrome,
                     )
                 }
+            }
             }
             }
         }
@@ -252,6 +263,12 @@ private fun CaptureFocusManager(onManager: (FocusManager) -> Unit) {
 @Composable
 internal fun WithWindowInfo(info: WindowInfo?, content: @Composable () -> Unit) {
     if (info == null) content() else CompositionLocalProvider(LocalWindowInfo provides info, content = content)
+}
+
+/** Runs [content] with [pick] answering "Play a recording", or with the real dialog when null. */
+@Composable
+private fun WithCastPicker(pick: (suspend () -> CastOpenResult)?, content: @Composable () -> Unit) {
+    if (pick == null) content() else CompositionLocalProvider(LocalCastPicker provides pick, content = content)
 }
 
 /**
@@ -483,6 +500,11 @@ internal fun ComposeUiTest.clickIconWhenEnabled(name: String, shell: DesktopShel
     // `!isSelectable()` because the nav rail's own entries carry the same names as some of the
     // toolbar's buttons ("Snippets" is both), and only the rail's are selectable navigation targets.
     val button = hasContentDescription(name) and isEnabled() and !isSelectable()
+    // Where the scene's own clock stood when the wait began. `waitUntil` spends wall clock and
+    // advances this by one 60Hz tick per turn, so the two together say how many frames the wait
+    // actually bought — the difference between a starved render loop and a settled composition
+    // that simply says no.
+    val startedAt = mainClock.currentTime
     try {
         waitUntil("\"$name\" to become clickable", timeoutMillis = 10_000) {
             onAllNodes(button).fetchSemanticsNodes().isNotEmpty()
@@ -491,7 +513,11 @@ internal fun ComposeUiTest.clickIconWhenEnabled(name: String, shell: DesktopShel
         // "Condition still not satisfied after 10000ms" names neither the button nor the reason it
         // stayed disabled, and this one only ever fails on a loaded runner — where a re-run to look
         // closer costs the whole suite. The tree and the session already hold the answer.
-        throw AssertionError("\"$name\" never became enabled. ${diagnose(name, shell)}", timeout)
+        throw AssertionError(
+            "\"$name\" never became enabled. ${diagnose(name, shell)} " +
+                "sceneMsAdvanced=${mainClock.currentTime - startedAt}",
+            timeout,
+        )
     }
     onNode(button).performClick()
 }
@@ -506,13 +532,49 @@ private fun ComposeUiTest.diagnose(name: String, shell: DesktopShell?): String {
     val pane = shell?.sessions?.active?.focusedPane
     val session = pane?.let { "pane=${it.id} state=${it.controller.uiState::class.simpleName}" } ?: "no active pane"
     val runner = shell?.runner?.let { "runnerActive=${it.active} pending=${it.pending != null} phase=${it.phase}" } ?: ""
+    // The rest of the row, which is what splits the answer in half. Every session action reads the
+    // same connected pane; only the runbook one also reads the runner. So a row that is disabled
+    // whole says the toolbar composed against a pane it still believes is down, and a row where
+    // only this button is off says the runner. A row that is not there at all says the toolbar was
+    // swapped out for another view.
+    val row = TOOLBAR_NEIGHBOURS.joinToString(" ") { neighbour ->
+        val label = string(neighbour)
+        val all = onAllNodes(hasContentDescription(label) and !isSelectable()).fetchSemanticsNodes()
+        val state = when {
+            all.isEmpty() -> "absent"
+            all.any { !it.config.contains(SemanticsProperties.Disabled) } -> "on"
+            else -> "off"
+        }
+        "$label=$state"
+    }
     // Whether one more settled frame flips it: a button still disabled after the tree goes idle is
     // a predicate that says no, not a frame the wait above failed to pump.
     waitForIdle()
-    val afterIdle = onAllNodes(hasContentDescription(name) and isEnabled() and !isSelectable())
-        .fetchSemanticsNodes().size
-    return "${nodes.size} node(s) carry that name: $drawn. $session $runner enabledAfterIdle=$afterIdle"
+    val afterIdle = enabledCount(name)
+    // And whether a frame driven by hand flips it. `waitForIdle` renders nothing at all when the
+    // tree already reads as idle, and a composition left behind by a write from another thread is
+    // exactly that: settled, and one frame short.
+    mainClock.advanceTimeByFrame()
+    val afterFrame = enabledCount(name)
+    return "${nodes.size} node(s) carry that name: $drawn. $session $runner " +
+        "row[$row] enabledAfterIdle=$afterIdle enabledAfterFrame=$afterFrame"
 }
+
+/** How many nodes named [name] are enabled right now. */
+@OptIn(ExperimentalTestApi::class)
+private fun ComposeUiTest.enabledCount(name: String): Int =
+    onAllNodes(hasContentDescription(name) and isEnabled() and !isSelectable()).fetchSemanticsNodes().size
+
+/**
+ * The session actions [diagnose] reads beside the button that timed out. Files is the control case:
+ * it is enabled whenever the toolbar is drawn at all, so "absent" there means the work area is
+ * showing something else entirely.
+ */
+private val TOOLBAR_NEIGHBOURS = listOf(
+    Res.string.shell_tip_files,
+    Res.string.shell_tip_snippets,
+    Res.string.shell_tip_record,
+)
 
 /**
  * Every string the tree draws, in order. Unmerged: a text node absorbed into a clickable ancestor's

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShortcutWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShortcutWiringTest.kt
@@ -3,12 +3,29 @@ package app.skerry.ui.desktop
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.withKeyDown
+import app.skerry.shared.ai.AiProviderKind
+import app.skerry.shared.terminal.Asciicast
 import app.skerry.ui.app.UiTags
+import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.session.SessionView
+import app.skerry.ui.snippet.SnippetDraft
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.shell_view_terminal
+import app.skerry.ui.terminal.CastOpenResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.getString
 import kotlin.test.Test
 
 /**
@@ -40,6 +57,139 @@ class ShortcutWiringTest {
     fun `the broadcast chord opens the broadcast panel`() = runDesktopShell { shell ->
         chord(Key.B)
         kotlin.test.assertTrue(shell.state.broadcastOpen, "the chord did not reach the broadcast panel")
+    }
+
+    /**
+     * The palette, the recorder and the player hang off toolbar buttons that only the terminal view
+     * draws. Pressed with the tab showing the file panel, the chord used to be spent on a request
+     * the parked toolbar never received; it has to bring that view forward and open the palette.
+     */
+    @Test
+    fun `the snippet chord opens the palette over the file panel`() = runDesktopShell { shell ->
+        shell.snippets.save(SnippetDraft(label = "Rollout", command = "uptime"))
+        shell.sessions?.setActiveView(SessionView.Sftp)
+        waitForIdle()
+
+        chord(Key.S)
+
+        // The palette opens on the frame after the view swap, and the request the chord raised is
+        // taken by an effect rather than by the click handler — so the assertion has to wait for it
+        // instead of reading the tree the key event landed on.
+        waitUntil("the snippet palette to open", timeoutMillis = 10_000) {
+            onAllNodesWithText("Rollout").fetchSemanticsNodes().isNotEmpty()
+        }
+        onNodeWithText("Rollout").assertIsDisplayed()
+    }
+
+    /** The same for the recorder: the toggle is the terminal toolbar's, the chord is the shell's. */
+    @Test
+    fun `the record chord starts recording over the file panel`() = runDesktopShell { shell ->
+        shell.sessions?.setActiveView(SessionView.Sftp)
+        waitForIdle()
+
+        chord(Key.R)
+
+        waitUntil("the recording to start", timeoutMillis = 10_000) { shell.recording() }
+        kotlin.test.assertEquals(SessionView.Terminal, shell.sessions?.active?.view)
+    }
+
+    /**
+     * Playback is the one chord of the set that answers without a toolbar at all — the picker lives
+     * in the window chrome. Deleting that driver leaves every other test green, so this is the only
+     * thing holding it in place.
+     *
+     * The file is named with a right-to-left override, because a recording arrives from whoever made
+     * it: the name becomes the tab label and with it the accessible name of that tab's close button,
+     * so an unfiltered one makes a chip read as a different chip.
+     */
+    @Test
+    fun `the playback chord opens a player tab over the file panel`() {
+        val cast = Asciicast(80, 24, "deploy", emptyList())
+        runDesktopShell(castPicker = { CastOpenResult.Loaded(cast, "report\u202Egpj.cast") }) { shell ->
+            shell.sessions?.setActiveView(SessionView.Sftp)
+            waitForIdle()
+
+            chord(Key.P)
+
+            waitUntil("the player tab to open", timeoutMillis = 10_000) {
+                shell.sessions?.active?.isPlayer == true
+            }
+            val tab = shell.sessions?.active
+            kotlin.test.assertEquals(SessionView.Player, tab?.view)
+            kotlin.test.assertEquals("reportgpj.cast", tab?.focusedPane?.title)
+            kotlin.test.assertEquals(cast, tab?.focusedPane?.playback?.cast)
+        }
+    }
+
+    /**
+     * The chord swaps what the work area shows without moving focus, so nothing tells a screen-reader
+     * user that the next keystroke goes to the terminal rather than the file list (WCAG 4.1.3).
+     */
+    @Test
+    fun `the view the chord brings forward is announced`() = runDesktopShell { shell ->
+        shell.snippets.save(SnippetDraft(label = "Rollout", command = "uptime"))
+        shell.sessions?.setActiveView(SessionView.Sftp)
+        waitForIdle()
+        val files = spokenViews()
+
+        chord(Key.S)
+
+        val terminal = runBlocking { getString(Res.string.shell_view_terminal) }
+        waitUntil("the work area to report the terminal", timeoutMillis = 10_000) {
+            terminal in spokenViews()
+        }
+        // The name, not merely a non-blank one: a mis-mapped `when` arm announces "Monitoring" for the
+        // terminal, and a live region carrying the wrong room is worse than one carrying none.
+        kotlin.test.assertTrue(terminal !in files, "the terminal was already being announced")
+    }
+
+    /**
+     * A recording is watched, not run, so the picker is up before any tab is involved — and a second
+     * native file dialog on top of the first hangs the app. The chord has to refuse while one is open.
+     */
+    @Test
+    fun `a second playback chord is refused while the picker is up`() {
+        val held = CompletableDeferred<CastOpenResult>()
+        var picks = 0
+        runDesktopShell(castPicker = { picks++; held.await() }) { shell ->
+            chord(Key.P)
+            waitUntil("the picker to go up", timeoutMillis = 10_000) { shell.state.castOpening }
+
+            chord(Key.P)
+            waitForIdle()
+
+            kotlin.test.assertEquals(1, picks, "a second file dialog was opened on top of the first")
+            held.complete(CastOpenResult.Cancelled)
+            waitUntil("the picker to close", timeoutMillis = 10_000) { !shell.state.castOpening }
+        }
+    }
+
+    /**
+     * The assistant panel is the only reader of the focus request, and it is not composed at all when
+     * AI is off for this host. An ask left pending there would surface on some later tab whose host has
+     * AI on, stealing the caret from the shell the user just switched to.
+     */
+    @Test
+    fun `an assistant ask nobody can take is dropped rather than carried to the next tab`() =
+        runDesktopShell { shell ->
+            shell.ai.selectProvider(AiProviderKind.OFF)
+            waitForIdle()
+
+            chord(Key.Slash)
+
+            waitUntil("the ask to be dropped", timeoutMillis = 10_000) { !shell.state.assistantFocusPending }
+        }
+
+    /** Every polite live region's text — the work area's is one of several the shell composes. */
+    private fun androidx.compose.ui.test.ComposeUiTest.spokenViews(): List<String> =
+        onAllNodes(SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, LiveRegionMode.Polite))
+            .fetchSemanticsNodes()
+            .flatMap { it.config.getOrNull(SemanticsProperties.ContentDescription).orEmpty() }
+
+    /** Whether the focused pane's terminal is recording — the state the record toggle flips. */
+    private fun DesktopShell.recording(): Boolean {
+        val state = sessions?.active?.focusedPane?.controller?.uiState
+        return (state as? ConnectionUiState.Connected)?.terminal?.recording == true
     }
 
     /** Ctrl+Shift+<letter> — what `matchDesktopShortcut` accepts on every platform, macOS included. */

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/share/ShareRequestTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/share/ShareRequestTest.kt
@@ -1,0 +1,38 @@
+package app.skerry.ui.share
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runDesktopComposeUiTest
+import app.skerry.ui.terminal.ToolbarRequest
+import app.skerry.ui.theme.SkerryTheme
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+/**
+ * What the share button does with an ask it cannot serve.
+ *
+ * The overflow menu raises the ask rather than opening the panel itself, and the row is lit whenever
+ * the pane has a terminal — including with sync disconnected, where there is no share controller and
+ * the button draws nothing at all. An ask left pending there does not disappear: it waits for the
+ * next composition that gets past the guards, and opens the streaming-consent panel over whatever
+ * session is active by then.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ShareRequestTest {
+
+    @Test
+    fun `an ask nobody can serve is taken and dropped`() = runDesktopComposeUiTest {
+        val request = ToolbarRequest()
+        setContent {
+            SkerryTheme {
+                // No controller: what the toolbar composes with sync disconnected.
+                ShareSessionButton(session = null, controller = null, teams = emptyList(), request = request)
+            }
+        }
+        waitForIdle()
+
+        request.raise()
+        waitForIdle()
+
+        assertFalse(request.pending, "the ask is parked for a later session to answer")
+    }
+}


### PR DESCRIPTION
Session chords now reach the toolbar buttons they nudge, whatever the tab is showing.

The snippet, recording and playback chords used to emit into a `MutableSharedFlow(replay = 0)`
whose only collectors live in the terminal toolbar. That toolbar is drawn by the terminal view
alone, so with the tab switched to Files, the monitor, a runbook run or a recording the chord was
spent on nobody and the palette never opened.

## What changed

- `ToolbarRequest` replaces the five one-shot flow channels: an ask is state, not an event, so it
  survives until the button that answers it composes. `OnToolbarRequest` is the one reader — it
  takes the ask and runs the action, and a second recomposition cannot fire it twice. A composition
  that bails before drawing a button takes the ask and drops it rather than leaving it pending:
  otherwise the Share row, lit whenever the pane has a terminal, could raise an ask with sync
  disconnected that opens the streaming-consent panel later, over a different session.
- The snippet and recording chords bring the terminal view forward before raising their ask. Both
  are already gated on a connected pane, so a remote-desktop or player tab never reaches that line.
- Playback leaves the toolbar entirely. Its `.cast` picker is now driven by `CastOpenDriver` in the
  window chrome, which is always composed, so Ctrl+Shift+P works over a remote desktop and over an
  already-open recording — neither of which draws a toolbar to bring up. The button keeps only the
  press, and both it and the overflow row go inert while a picker is up, since a second file dialog
  on top of the first hangs the app.
- The recording's file name is filtered before it labels the player tab: a tab title is also the
  accessible name of that tab's close button, and a recording is named by whoever made it.
- The work area now says which view it is showing, through a polite live region above the pane. A
  chord that swaps Files for the terminal moves no focus, so nothing told a screen-reader user that
  the next keystroke goes somewhere else (WCAG 2.2 SC 4.1.3).

## Harness

`clickIconWhenEnabled`'s failure dump now also reports the state of the neighbouring toolbar
buttons, whether a hand-driven frame flips the button, and how much scene time the wait bought.
Those three split the `RunbookEditorFormTest` flake (#338) between a starved render loop, a stale
composition and the runbook runner — which the dump it produces today cannot do.

The `.cast` picker is reachable from a test for the first time (`LocalCastPicker`), which is what
holds `CastOpenDriver` in place: deleting it used to leave the whole suite green. The same seam pins
the picker guard and the sanitising of the file name the tab is labelled with.

Fixes #337
