### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,5 +20,5 @@ android.useAndroidX=true
 # seeded at 116 because the APKs published up to 0.4.0 carried the CI run number instead of this
 # value, and the last one shipped as 115. The `version-bump` check blocks a versionName bump that
 # leaves the code behind.
-skerry.versionName=0.4.1
-skerry.versionCode=116
+skerry.versionName=0.4.2
+skerry.versionCode=117

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.4.1"
+version = "0.4.2"
 
 // Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
 // to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.4.1"
+version = "0.4.2"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Client and server both move to 0.4.2.

What is in the release:

- Session sharing: the relay names the viewer instead of the viewer naming itself, the Grant/Deny prompt is throttled, and joining a share with a long history no longer detaches the viewer.
- Files and transfers: bounded and de-duplicated directory listings, capped recursive walks, a transfer queue for an operation picked while another one runs, and confirmed deletes and renames that are never dropped.
- Toolbar and shortcuts: actions with nothing to act on are disabled, and the snippet, recording and playback chords reach the toolbar whatever pane is in front.
- Teams: a failed member removal reports the failure that matters, and a refused key is named in the member list.
- Protocol fixes across VNC, Telnet, ssh_config and tunnels, plus SRP material validation on the sync server.

`skerry.versionCode` moves 116 → 117.