### PR TITLE
feat(ui): add manual folder drag-and-drop reordering for snippets and runbooks, and enhance folder drag UX

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FolderSectionHeader.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FolderSectionHeader.kt
@@ -1,20 +1,25 @@
 package app.skerry.ui.design
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -26,22 +31,15 @@ import androidx.compose.ui.unit.sp
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shtail_group_collapse
 import app.skerry.ui.generated.resources.shtail_group_expand
+import app.skerry.ui.generated.resources.shtail_group_rename
 import app.skerry.ui.generated.resources.shtail_group_state_collapsed
 import app.skerry.ui.generated.resources.shtail_group_state_expanded
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Folder header of a list section: chevron + folder icon + name + count, the whole row folding the
- * section on a click.
- *
- * The host sidebar's own header ([app.skerry.ui.terminal] `FolderHeader`) stays separate because
- * there the row is a drag handle and a drop target, so only its chevron may take the click. Here
- * nothing is dragged, and the full-width row is the target — which is also what makes it usable on
- * a phone, where a 22dp chevron is not.
- *
- * The row names itself after what a click does and to which folder: a screen of headers all saying
- * "Collapse" says nothing about which one is which.
+ * Folder header of a list section: chevron + folder icon + name + count.
+ * The chevron toggles collapsed state; the header body acts as a drag surface.
  */
 @Composable
 fun FolderSectionHeader(
@@ -51,37 +49,75 @@ fun FolderSectionHeader(
     onToggle: () -> Unit,
     modifier: Modifier = Modifier,
     padding: PaddingValues = PaddingValues(horizontal = 18.dp, vertical = 8.dp),
+    onEdit: (() -> Unit)? = null,
+    isDragging: Boolean = false,
+    isDropTarget: Boolean = false,
 ) {
     val label = folderLabel(name)
     val action = stringResource(
         if (collapsed) Res.string.shtail_group_expand else Res.string.shtail_group_collapse,
         label,
     )
-    // The click label says what a click would do; the state says where the folder stands now. A
-    // reader with action hints turned down hears only the latter, and without it hears neither.
     val state = stringResource(
         if (collapsed) Res.string.shtail_group_state_collapsed else Res.string.shtail_group_state_expanded,
     )
+
     Row(
         modifier
             .fillMaxWidth()
-            .clickable(onClickLabel = action, role = Role.Button, onClick = onToggle)
-            .semantics { stateDescription = state }
+            .clip(RoundedCornerShape(6.dp))
+            .background(
+                when {
+                    isDragging -> Skerry.colors.card
+                    isDropTarget -> Skerry.colors.cyan.copy(alpha = 0.12f)
+                    else -> Color.Transparent
+                }
+            )
+            .border(
+                1.dp,
+                when {
+                    isDragging -> Skerry.colors.cyan
+                    isDropTarget -> Skerry.colors.cyanBright
+                    else -> Color.Transparent
+                },
+                RoundedCornerShape(6.dp)
+            )
             .padding(padding),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(7.dp),
     ) {
-        Sym(if (collapsed) "chevron_right" else "expand_more", size = 16.sp, color = Skerry.colors.faint)
-        Sym("folder_open", size = 15.sp, color = Skerry.colors.cyanBright)
+        Box(
+            Modifier
+                .size(22.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .clickable(onClickLabel = action, role = Role.Button, onClick = onToggle)
+                .semantics { stateDescription = state },
+            contentAlignment = Alignment.Center,
+        ) {
+            Sym(if (collapsed) "chevron_right" else "expand_more", size = 16.sp, color = Skerry.colors.faint)
+        }
+        Sym("folder_open", size = 15.sp, color = if (isDragging || isDropTarget) Skerry.colors.cyanBright else Skerry.colors.cyanBright)
         Txt(
             label,
-            color = Skerry.colors.dim,
+            color = if (isDragging || isDropTarget) Skerry.colors.cyanBright else Skerry.colors.dim,
             size = 12.5.sp,
             weight = FontWeight.Medium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f, fill = false),
+            modifier = Modifier
+                .weight(1f)
+                .clickable(onClickLabel = action, role = Role.Button, onClick = onToggle),
         )
+        if (onEdit != null) {
+            IconBtn(
+                "edit",
+                onClick = onEdit,
+                box = 20,
+                icon = 13.sp,
+                tint = Skerry.colors.faint,
+                tooltip = stringResource(Res.string.shtail_group_rename, label),
+            )
+        }
         Box(
             Modifier.clip(RoundedCornerShape(8.dp)).background(Skerry.colors.card)
                 .padding(horizontal = 6.dp, vertical = 1.dp),
@@ -92,24 +128,13 @@ fun FolderSectionHeader(
 }
 
 /**
- * Header padding on a phone. The whole row is the fold target and it gets tapped over and over, so
- * it stays clear of the floor a finger needs; the horizontal inset is the list's own, because the
- * header lines up with the cards under it and each list insets those differently.
+ * Header padding on a phone.
  */
 fun mobileFolderHeaderPadding(horizontal: Dp = 0.dp): PaddingValues =
     PaddingValues(horizontal = horizontal, vertical = 8.dp)
 
 /**
- * A list rendered as folder sections: a [FolderSectionHeader] per folder, then that folder's rows,
- * with a collapsed folder drawing its header alone. Emits into the caller's layout, so the list's
- * own container (scroll, spacing, padding) stays where it was.
- *
- * With nothing filed anywhere the rows are emitted flat, unchanged: folders are opt-in, and a
- * library that has never used one must not sprout an "Ungrouped" header on upgrade ([hasFolders]).
- *
- * [scope] namespaces the fold state ([folderCollapseKey]) — pass a constant per list, not a value
- * derived from what is on screen. [itemKey] is the stable identity of a row, so folding a folder
- * does not make Compose rebuild the rows of the ones below it.
+ * A list rendered as folder sections with optional drag-and-drop reordering and group management.
  */
 @Composable
 fun <T> FolderSections(
@@ -117,29 +142,193 @@ fun <T> FolderSections(
     scope: String,
     collapse: FolderCollapse,
     group: (T) -> String?,
-    itemKey: (T) -> Any,
+    itemKey: (T) -> String,
+    selectedIds: Set<String> = emptySet(),
     headerPadding: PaddingValues = PaddingValues(horizontal = 18.dp, vertical = 8.dp),
+    longPress: Boolean = false,
+    onEditGroup: ((String) -> Unit)? = null,
+    onMoveItem: ((itemId: String, targetGroup: String?, targetIndexInGroup: Int) -> Unit)? = null,
+    onMoveItems: ((itemIds: Set<String>, targetGroup: String?, targetIndexInGroup: Int) -> Unit)? = null,
+    onMoveGroup: ((group: String?, targetGroupIndex: Int) -> Unit)? = null,
     item: @Composable (T) -> Unit,
 ) {
-    if (!hasFolders(items, group)) {
+    val groupList = items.map { group(it) }
+    val folders = remember(items, groupList) { foldersOf(items, group) }
+    val hasAnyFolders = hasFolders(items, group)
+
+    val canMove = onMoveItems != null || onMoveItem != null
+    val canMoveGroup = onMoveGroup != null
+    if (!hasAnyFolders && !canMove && !canMoveGroup) {
         items.forEach { row -> key(itemKey(row)) { item(row) } }
         return
     }
-    // Sorting the whole library on every recomposition would be paid for on each fold of each
-    // header; the list itself only changes when a record is saved.
-    val folders = remember(items) { foldersOf(items, group) }
-    folders.forEach { folder ->
-        key(folder.name) {
-            val collapseKey = folderCollapseKey(scope, folder.name)
-            val collapsed = collapse.isGroupCollapsed(collapseKey)
-            FolderSectionHeader(
-                name = folder.name,
-                count = folder.items.size,
-                collapsed = collapsed,
-                onToggle = { collapse.toggleGroupCollapsed(collapseKey) },
-                padding = headerPadding,
-            )
-            if (!collapsed) folder.items.forEach { row -> key(itemKey(row)) { item(row) } }
+
+    val performMove: (Set<String>, String?, Int) -> Unit = { ids, targetGroup, targetIndex ->
+        if (onMoveItems != null) {
+            onMoveItems(ids, targetGroup, targetIndex)
+        } else if (onMoveItem != null) {
+            ids.forEachIndexed { i, id ->
+                onMoveItem(id, targetGroup, targetIndex + i)
+            }
         }
     }
+
+    val dragState = remember { ListDragState() }
+
+    if (!hasAnyFolders) {
+        val singleFolder = Folder(UNGROUPED_FOLDER, items)
+        val others = items.filter { !dragState.isItemDragging(itemKey(it)) }
+        val isDropTarget = dragState.isDragging && dragState.activeDrop?.group == null
+        val dropIndex = if (isDropTarget) dragState.activeDrop?.index?.coerceIn(0, others.size) else null
+        val lineBeforeId = dropIndex?.takeIf { it < others.size }?.let { itemKey(others[it]) }
+
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .folderRangeAnchor(dragState, UNGROUPED_FOLDER)
+        ) {
+            items.forEach { row ->
+                val key = itemKey(row)
+                key(key) {
+                    if (key == lineBeforeId) ListDropLine()
+                    val isRowDragging = dragState.isItemDragging(key)
+                    val isAnchor = dragState.anchorId == key
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .itemBoundsAnchor(dragState, key)
+                            .alpha(if (isRowDragging) 0.4f else 1f)
+                            .then(
+                                if (canMove) {
+                                    Modifier.draggableItemRow(
+                                        state = dragState,
+                                        id = key,
+                                        folders = { listOf(singleFolder) },
+                                        keyOf = itemKey,
+                                        selectedIds = { selectedIds },
+                                        longPress = longPress,
+                                        onDrop = { drop, movingIds -> performMove(movingIds, drop.group, drop.index) },
+                                    )
+                                } else Modifier
+                            )
+                    ) {
+                        item(row)
+                        if (isAnchor && dragState.draggingIds.size > 1) {
+                            Box(
+                                Modifier
+                                    .align(Alignment.CenterEnd)
+                                    .padding(end = 24.dp)
+                            ) {
+                                DragBatchBadge(dragState.draggingIds.size)
+                            }
+                        }
+                    }
+                }
+            }
+            if (dropIndex != null && dropIndex == others.size) ListDropLine()
+        }
+        return
+    }
+
+    val otherFolders = folders.filter { it.name != dragState.draggingFolderName }
+    val folderLineIndex = dragState.draggingFolderName?.let { dragState.activeFolderDropIndex }
+    val folderLineBefore = folderLineIndex?.takeIf { it < otherFolders.size }?.let { otherFolders[it].name }
+
+    folders.forEach { folder ->
+        key(folder.name) {
+            if (folder.name == folderLineBefore) ListDropLine()
+            val collapseKey = folderCollapseKey(scope, folder.name)
+            val collapsed = collapse.isGroupCollapsed(collapseKey)
+            val targetGroup = if (folder.name == UNGROUPED_FOLDER) null else folder.name
+            val isDropTarget = dragState.isDragging && dragState.activeDrop?.group == targetGroup
+            val onEdit = if (folder.name != UNGROUPED_FOLDER && onEditGroup != null) {
+                { onEditGroup(folder.name) }
+            } else null
+
+            val others = folder.items.filter { !dragState.isItemDragging(itemKey(it)) }
+            val dropIndex = if (isDropTarget) dragState.activeDrop?.index?.coerceIn(0, others.size) else null
+            val lineBeforeId = dropIndex?.takeIf { it < others.size }?.let { itemKey(others[it]) }
+
+            val isAnyFolderDragging = dragState.draggingFolderName != null
+            val isThisFolderDragging = dragState.isFolderDragging(folder.name)
+            val folderAlpha = if (isThisFolderDragging) 0.6f else 1f
+
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .alpha(folderAlpha)
+                    .folderRangeAnchor(dragState, folder.name)
+            ) {
+                val headerModifier = if (canMoveGroup && folder.name != UNGROUPED_FOLDER) {
+                    Modifier
+                        .fillMaxWidth()
+                        .folderHeaderAnchor(dragState, folder.name)
+                        .draggableFolderHeader(
+                            state = dragState,
+                            name = folder.name,
+                            folders = { folders },
+                            longPress = longPress,
+                            onDrop = { targetIndex ->
+                                onMoveGroup?.invoke(targetGroup, targetIndex)
+                            },
+                        )
+                } else Modifier.fillMaxWidth()
+
+                Box(headerModifier) {
+                    FolderSectionHeader(
+                        name = folder.name,
+                        count = folder.items.size,
+                        collapsed = collapsed,
+                        onToggle = { collapse.toggleGroupCollapsed(collapseKey) },
+                        padding = headerPadding,
+                        onEdit = onEdit,
+                        isDragging = isThisFolderDragging,
+                        isDropTarget = isDropTarget,
+                    )
+                }
+                // When any folder is being dragged, temporarily collapse all folders into compact headers
+                // so the user can easily reorder between groups without list jumping.
+                if (!collapsed && !isAnyFolderDragging) {
+                    folder.items.forEach { row ->
+                        val key = itemKey(row)
+                        key(key) {
+                            if (key == lineBeforeId) ListDropLine()
+                            val isRowDragging = dragState.isItemDragging(key)
+                            val isAnchor = dragState.anchorId == key
+                            val rowModifier = if (canMove) {
+                                Modifier
+                                    .fillMaxWidth()
+                                    .itemBoundsAnchor(dragState, key)
+                                    .alpha(if (isRowDragging) 0.4f else 1f)
+                                    .draggableItemRow(
+                                        state = dragState,
+                                        id = key,
+                                        folders = { folders },
+                                        keyOf = itemKey,
+                                        selectedIds = { selectedIds },
+                                        longPress = longPress,
+                                        onDrop = { drop, movingIds -> performMove(movingIds, drop.group, drop.index) },
+                                    )
+                            } else Modifier.fillMaxWidth()
+
+                            Box(rowModifier) {
+                                item(row)
+                                if (isAnchor && dragState.draggingIds.size > 1) {
+                                    Box(
+                                        Modifier
+                                            .align(Alignment.CenterEnd)
+                                            .padding(end = 24.dp)
+                                    ) {
+                                        DragBatchBadge(dragState.draggingIds.size)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (dropIndex != null && dropIndex == others.size) ListDropLine()
+                }
+            }
+        }
+    }
+    if (folderLineIndex != null && folderLineIndex == otherFolders.size) ListDropLine()
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FolderSectionsDnd.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FolderSectionsDnd.kt
@@ -1,0 +1,346 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.host.FolderBounds
+import app.skerry.ui.host.HostDrop
+import app.skerry.ui.host.folderDropTarget
+import app.skerry.ui.theme.Skerry
+import kotlinx.coroutines.CancellationException
+
+private val MOUSE_DRAG_DEAD_ZONE = 6.dp
+
+private class DragTrackingState(val startPosition: Offset) {
+    var dragging = false
+    var accumulated = Offset.Zero
+
+    fun onDelta(
+        change: PointerInputChange,
+        threshold: Float,
+        onStart: (Offset) -> Unit,
+        onMove: (PointerInputChange, Offset) -> Unit,
+    ) {
+        val delta = change.positionChange()
+        if (dragging) {
+            if (delta != Offset.Zero) {
+                change.consume()
+                onMove(change, delta)
+            }
+        } else {
+            accumulated += delta
+            if (accumulated.getDistance() >= threshold) {
+                dragging = true
+                change.consume()
+                onStart(startPosition)
+                onMove(change, accumulated)
+            }
+        }
+    }
+}
+
+suspend fun PointerInputScope.detectDeadZoneDragGestures(
+    onStart: (Offset) -> Unit,
+    onMove: (PointerInputChange, Offset) -> Unit,
+    onEnd: () -> Unit,
+    onCancel: () -> Unit,
+) = awaitEachGesture {
+    val down = awaitFirstDown(requireUnconsumed = false)
+    val threshold =
+        if (down.type == PointerType.Mouse) MOUSE_DRAG_DEAD_ZONE.toPx() else viewConfiguration.touchSlop
+    val tracker = DragTrackingState(down.position)
+    try {
+        while (true) {
+            val event = awaitPointerEvent()
+            val change = event.changes.firstOrNull { it.id == down.id }
+            if (change == null) {
+                if (tracker.dragging) onCancel()
+                break
+            }
+            if (change.changedToUpIgnoreConsumed()) {
+                if (tracker.dragging) onEnd()
+                break
+            }
+            tracker.onDelta(change, threshold, onStart, onMove)
+        }
+    } catch (e: CancellationException) {
+        if (tracker.dragging) onCancel()
+        throw e
+    }
+}
+
+/**
+ * Drag state for item lists partitioned into folders (Snippets, Runbooks, Keychain).
+ * Supports single-item and multi-selection batch dragging and folder drop targeting.
+ */
+@Stable
+class ListDragState {
+    var draggingIds by mutableStateOf<Set<String>>(emptySet())
+        private set
+
+    var anchorId by mutableStateOf<String?>(null)
+        private set
+
+    var activeDrop by mutableStateOf<HostDrop?>(null)
+        private set
+
+    var draggingFolderName by mutableStateOf<String?>(null)
+        private set
+
+    var activeFolderDropIndex by mutableStateOf<Int?>(null)
+        private set
+
+    val draggingId: String? get() = anchorId ?: draggingIds.firstOrNull()
+
+    private var pointerY = 0f
+    private val itemBounds = HashMap<String, Rect>()
+    private val folderRange = HashMap<String, Rect>()
+    private val folderHeader = HashMap<String, Rect>()
+
+    val isDragging: Boolean get() = draggingIds.isNotEmpty() || draggingFolderName != null
+
+    fun isItemDragging(id: String): Boolean = id in draggingIds
+    fun isFolderDragging(name: String): Boolean = name == draggingFolderName
+
+    fun setItemBounds(id: String, rect: Rect) { itemBounds[id] = rect }
+    fun clearItemBounds(id: String) { itemBounds.remove(id) }
+    fun setFolderRange(name: String, rect: Rect) { folderRange[name] = rect }
+    fun setFolderHeader(name: String, rect: Rect) { folderHeader[name] = rect }
+    fun clearFolderHeader(name: String) { folderHeader.remove(name) }
+
+    fun startFolderDrag(name: String, localOffsetY: Float) {
+        draggingFolderName = name
+        pointerY = (folderHeader[name]?.top ?: 0f) + localOffsetY
+    }
+
+    fun <T> currentFolderDropIndex(folders: List<Folder<T>>): Int {
+        val centers = folders
+            .filter { it.name != draggingFolderName }
+            .mapNotNull { folderHeader[it.name]?.let { b -> (b.top + b.bottom) / 2f } }
+        return folderDropTarget(centers, pointerY)
+    }
+
+    fun <T> refreshFolderDrop(folders: List<Folder<T>>) {
+        val next = currentFolderDropIndex(folders)
+        if (next != activeFolderDropIndex) activeFolderDropIndex = next
+    }
+
+    fun startDrag(id: String, localOffsetY: Float, selectedIds: Set<String> = emptySet()) {
+        anchorId = id
+        draggingIds = if (id in selectedIds) selectedIds else setOf(id)
+        pointerY = (itemBounds[id]?.top ?: 0f) + localOffsetY
+    }
+
+    fun dragBy(deltaY: Float) {
+        pointerY += deltaY
+    }
+
+    fun <T> folderBounds(folders: List<Folder<T>>, keyOf: (T) -> String): List<FolderBounds> =
+        folders.mapNotNull { folder ->
+            val range = folderRange[folder.name] ?: return@mapNotNull null
+            FolderBounds(
+                group = if (folder.name == UNGROUPED_FOLDER) null else folder.name,
+                top = range.top,
+                bottom = range.bottom,
+                otherHostCentersY = folder.items
+                    .filter { keyOf(it) !in draggingIds }
+                    .mapNotNull { itemBounds[keyOf(it)]?.let { b -> (b.top + b.bottom) / 2f } },
+            )
+        }
+
+    fun <T> refreshDrop(folders: List<Folder<T>>, keyOf: (T) -> String) {
+        val next = currentDrop(folders, keyOf)
+        if (next != activeDrop) activeDrop = next
+    }
+
+    fun <T> currentDrop(folders: List<Folder<T>>, keyOf: (T) -> String): HostDrop? {
+        val bounds = folderBounds(folders, keyOf)
+        if (bounds.isEmpty()) return null
+        val matchingFolder = bounds.firstOrNull { pointerY >= it.top - 16f && pointerY <= it.bottom + 16f }
+            ?: if (pointerY < bounds.first().top) bounds.first() else bounds.last()
+        val index = matchingFolder.otherHostCentersY.count { it < pointerY }
+        return HostDrop(matchingFolder.group, index)
+    }
+
+    fun endDrag() {
+        draggingIds = emptySet()
+        anchorId = null
+        activeDrop = null
+        draggingFolderName = null
+        activeFolderDropIndex = null
+    }
+}
+
+fun Modifier.itemBoundsAnchor(state: ListDragState, id: String): Modifier =
+    onGloballyPositioned { state.setItemBounds(id, it.boundsInWindow()) }
+
+fun Modifier.folderRangeAnchor(state: ListDragState, name: String): Modifier =
+    onGloballyPositioned { state.setFolderRange(name, it.boundsInWindow()) }
+
+fun Modifier.folderHeaderAnchor(state: ListDragState, name: String): Modifier =
+    onGloballyPositioned { state.setFolderHeader(name, it.boundsInWindow()) }
+
+fun <T> Modifier.draggableFolderHeader(
+    state: ListDragState,
+    name: String,
+    folders: () -> List<Folder<T>>,
+    longPress: Boolean = false,
+    onDrop: (Int) -> Unit,
+): Modifier = pointerInput(name, longPress) {
+    var moved = false
+    val onStart = { offset: Offset ->
+        moved = false
+        state.startFolderDrag(name, offset.y)
+        state.refreshFolderDrop(folders())
+    }
+    val onMove = { change: PointerInputChange, amount: Offset ->
+        change.consume()
+        moved = true
+        state.dragBy(amount.y)
+        state.refreshFolderDrop(folders())
+    }
+    val onEnd = {
+        if (moved) {
+            val dropIndex = state.activeFolderDropIndex ?: state.currentFolderDropIndex(folders())
+            onDrop(dropIndex)
+        }
+        state.endDrag()
+    }
+    val onCancel = { state.endDrag() }
+    if (longPress) {
+        detectDragGesturesAfterLongPress(
+            onDragStart = onStart,
+            onDrag = onMove,
+            onDragEnd = onEnd,
+            onDragCancel = onCancel,
+        )
+    } else {
+        detectDeadZoneDragGestures(
+            onStart = onStart,
+            onMove = onMove,
+            onEnd = onEnd,
+            onCancel = onCancel,
+        )
+    }
+}
+
+fun <T> Modifier.draggableItemRow(
+    state: ListDragState,
+    id: String,
+    folders: () -> List<Folder<T>>,
+    keyOf: (T) -> String,
+    selectedIds: () -> Set<String> = { emptySet() },
+    longPress: Boolean = false,
+    onDrop: (drop: HostDrop, movingIds: Set<String>) -> Unit,
+): Modifier = pointerInput(id, longPress) {
+    var moved = false
+    val onStart = { offset: Offset ->
+        moved = false
+        state.startDrag(id, offset.y, selectedIds())
+        state.refreshDrop(folders(), keyOf)
+    }
+    val onMove = { change: PointerInputChange, amount: Offset ->
+        change.consume()
+        moved = true
+        state.dragBy(amount.y)
+        state.refreshDrop(folders(), keyOf)
+    }
+    val onEnd = {
+        if (moved) {
+            val drop = state.activeDrop ?: state.currentDrop(folders(), keyOf)
+            val moving = state.draggingIds
+            if (drop != null && moving.isNotEmpty()) {
+                onDrop(drop, moving)
+            }
+        }
+        state.endDrag()
+    }
+    val onCancel = { state.endDrag() }
+    if (longPress) {
+        detectDragGesturesAfterLongPress(onDragStart = onStart, onDrag = onMove, onDragEnd = onEnd, onDragCancel = onCancel)
+    } else {
+        detectDeadZoneDragGestures(onStart, onMove, onEnd, onCancel)
+    }
+}
+
+@Composable
+fun ListDropLine(
+    modifier: Modifier = Modifier,
+    horizontal: Dp = 18.dp,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = horizontal, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            Modifier
+                .size(6.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(Skerry.colors.cyanBright)
+        )
+        Box(
+            Modifier
+                .weight(1f)
+                .height(3.dp)
+                .clip(RoundedCornerShape(1.5.dp))
+                .background(Skerry.colors.cyan)
+        )
+        Box(
+            Modifier
+                .size(6.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(Skerry.colors.cyanBright)
+        )
+    }
+}
+
+@Composable
+fun DragBatchBadge(count: Int, modifier: Modifier = Modifier) {
+    Box(
+        modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(Skerry.colors.cyanBright)
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Txt(
+            text = "+$count",
+            color = Color.Black,
+            size = 10.5.sp,
+            weight = FontWeight.Bold,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/Folders.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/Folders.kt
@@ -52,19 +52,17 @@ fun folderLabel(name: String): String = when (name) {
 }
 
 /**
- * Split [items] into folders by [group]: named folders first, in case-insensitive alphabetical
- * order, then the [UNGROUPED_FOLDER] bucket for everything whose group is `null` or blank. Items keep
+ * Split [items] into folders by [group]: named folders in order of first appearance,
+ * then the [UNGROUPED_FOLDER] bucket for everything whose group is `null` or blank. Items keep
  * their source order inside a folder, and an empty [items] gives no folders at all.
  *
- * Alphabetical rather than first-appearance (which is what host folders use): a host list has an
- * order the user drags into shape and its folders inherit it, while a snippet, a runbook and a
- * keychain secret sit in store order — first appearance there is the order things happened to be
- * created in, which is no order at all once there are twenty of them.
+ * First-appearance matches host folders: the list has an order the user drags into shape
+ * and its folders inherit it, supporting manual drag-and-drop group reordering across devices.
  *
  * Pure function (no Compose), shared by the desktop sections and the mobile ones.
  */
 fun <T> foldersOf(items: List<T>, group: (T) -> String?): List<Folder<T>> {
-    val named = sortedMapOf<String, MutableList<T>>(compareBy({ it.lowercase() }, { it }))
+    val named = LinkedHashMap<String, MutableList<T>>()
     val ungrouped = mutableListOf<T>()
     for (item in items) {
         val name = storedFolderName(group(item))
@@ -151,4 +149,10 @@ private const val HEX = 16
 interface FolderCollapse {
     fun isGroupCollapsed(name: String): Boolean
     fun toggleGroupCollapsed(name: String)
+    fun expandGroup(name: String) {
+        if (isGroupCollapsed(name)) toggleGroupCollapsed(name)
+    }
+    fun collapseGroup(name: String) {
+        if (!isGroupCollapsed(name)) toggleGroupCollapsed(name)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSidebarDnd.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSidebarDnd.kt
@@ -177,8 +177,7 @@ internal suspend fun PointerInputScope.detectDeadZoneDragGestures(
         while (true) {
             val event = awaitPointerEvent()
             val change = event.changes.firstOrNull { it.id == down.id }
-            if (change == null || (change.isConsumed && !change.changedToUpIgnoreConsumed())) {
-                // Pointer stream broken, or a deeper handler claimed a non-up change.
+            if (change == null) {
                 if (dragging) onCancel()
                 break
             }
@@ -241,7 +240,10 @@ fun Modifier.draggableHostRow(
     }
     val onEnd = {
         // Without an actual move (a micro-gesture from a tap) the catalog and disk stay untouched.
-        if (moved) state.currentHostDrop(folders())?.let(onDrop)
+        if (moved) {
+            val drop = state.activeHostDrop ?: state.currentHostDrop(folders())
+            drop?.let(onDrop)
+        }
         state.endDrag()
     }
     val onCancel = { state.endDrag() }
@@ -277,7 +279,10 @@ fun Modifier.draggableFolderHeader(
         state.refreshFolderDrop(folders())
     }
     val onEnd = {
-        if (moved) onDrop(state.currentFolderDropIndex(folders()))
+        if (moved) {
+            val dropIndex = state.activeFolderDropIndex ?: state.currentFolderDropIndex(folders())
+            onDrop(dropIndex)
+        }
         state.endDrag()
     }
     val onCancel = { state.endDrag() }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsChrome.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -178,9 +179,16 @@ internal fun MobileFolderHeader(
     dropTarget: Boolean,
     onToggle: () -> Unit,
     onEdit: (() -> Unit)?,
+    isDragging: Boolean = false,
 ) {
     Row(
-        Modifier.fillMaxWidth().padding(start = 18.dp, end = 22.dp, top = 16.dp, bottom = 4.dp),
+        Modifier
+            .fillMaxWidth()
+            .padding(start = 18.dp, end = 22.dp, top = if (isDragging) 8.dp else 16.dp, bottom = 4.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(if (isDragging) Skerry.colors.card else Color.Transparent)
+            .border(1.dp, if (isDragging) Skerry.colors.cyan else Color.Transparent, RoundedCornerShape(6.dp))
+            .padding(horizontal = if (isDragging) 8.dp else 0.dp, vertical = if (isDragging) 6.dp else 0.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
@@ -212,7 +220,7 @@ internal fun MobileFolderHeader(
         // far right, where it read as a column of unrelated numbers down the screen.
         Txt(
             "${name.uppercase()} · $count",
-            color = if (dropTarget) Skerry.colors.cyanBright else Skerry.colors.faint,
+            color = if (isDragging || dropTarget) Skerry.colors.cyanBright else Skerry.colors.faint,
             size = 12.sp,
             weight = FontWeight.SemiBold,
             letterSpacing = 0.6.sp,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
@@ -7,6 +7,7 @@ import app.skerry.ui.host.rowSubtitle
 import app.skerry.ui.host.rowLabel
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -170,9 +171,11 @@ private fun MobileHostFolder(
     // (stable slot-table position); takeIf controls pencil visibility.
     val onEdit = remember(state, folder.name) { { state.openRenameGroup(folder.name) } }
         .takeIf { controller != null && folder.name != UNGROUPED_LABEL }
+    val isAnyFolderDragging = dragState.draggingFolderName != null
+    val isThisFolderDragging = dragState.draggingFolderName == folder.name
     // Highlights the target folder while a host is dragged over it.
     val isDropTarget = dragState.draggingHostId != null && dragState.activeHostDrop?.group == group
-    val folderAlpha = if (dragState.draggingFolderName == folder.name) 0.4f else 1f
+    val folderAlpha = if (isThisFolderDragging) 0.6f else 1f
     // Insertion line index within the folder, excluding the dragged host (like moveHostToGroup).
     val others = folder.hosts.filter { it.id != dragState.draggingHostId }
     val dropIndex = if (isDropTarget) dragState.activeHostDrop?.index?.coerceIn(0, others.size) else null
@@ -186,7 +189,12 @@ private fun MobileHostFolder(
             Modifier
                 .folderHeaderAnchor(dragState, folder.name)
                 // Section-aware, like desktop: the index counts only the folders on screen.
-                .draggableFolderHeader(dragState, folder.name, foldersProvider, longPress = true) { index ->
+                .draggableFolderHeader(
+                    state = dragState,
+                    name = folder.name,
+                    folders = foldersProvider,
+                    longPress = true,
+                ) { index ->
                     controller.moveFolderInSection(group, index, section)
                 }
         } else {
@@ -196,10 +204,11 @@ private fun MobileHostFolder(
             // folder.name is a stable key (drag/collapse); the ungrouped bucket shows a localized
             // label while keeping the key technical ([UNGROUPED_LABEL]).
             val folderTitle = if (folder.name == UNGROUPED_LABEL) ungroupedLabel() else folder.name
-            MobileFolderHeader(folderTitle, folder.hosts.size, collapsed, isDropTarget, onToggle, onEdit)
+            MobileFolderHeader(folderTitle, folder.hosts.size, collapsed, isDropTarget, onToggle, onEdit, isDragging = isThisFolderDragging)
         }
-        // A collapsed folder shows only its header; the host list (and its drag targets) is hidden.
-        if (!collapsed) {
+        // A collapsed folder shows only its header; when any folder is dragged, all folders
+        // temporarily collapse to allow fast, compact and predictable folder reordering.
+        if (!collapsed && !isAnyFolderDragging) {
             Column(Modifier.padding(horizontal = 22.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 folder.hosts.forEach { host ->
                     key(host.id) {
@@ -240,14 +249,32 @@ private fun MobileHostFolder(
  */
 @Composable
 private fun MobileDropLine(horizontal: Dp = 18.dp) {
-    Box(
+    Row(
         Modifier
             .fillMaxWidth()
-            .padding(horizontal = horizontal, vertical = 3.dp)
-            .height(2.dp)
-            .clip(RoundedCornerShape(1.dp))
-            .background(Skerry.colors.cyan),
-    )
+            .padding(horizontal = horizontal, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            Modifier
+                .size(6.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(Skerry.colors.cyanBright)
+        )
+        Box(
+            Modifier
+                .weight(1f)
+                .height(3.dp)
+                .clip(RoundedCornerShape(1.5.dp))
+                .background(Skerry.colors.cyan)
+        )
+        Box(
+            Modifier
+                .size(6.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(Skerry.colors.cyanBright)
+        )
+    }
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookGrouping.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookGrouping.kt
@@ -1,6 +1,18 @@
 package app.skerry.ui.runbook
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import app.skerry.ui.design.UNGROUPED_FOLDER
+import app.skerry.ui.design.folderLabel
 import app.skerry.ui.design.folderNames
+import app.skerry.ui.design.foldersOf
+import app.skerry.ui.design.hasFolders
+import app.skerry.ui.design.tagChipLabel
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippets_chip_all
+import app.skerry.ui.snippet.UNCATEGORIZED_KEY
+import app.skerry.ui.snippet.uncategorizedSnippetsLabel
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * Names the library's folders in the one collapsed set the app persists
@@ -9,6 +21,88 @@ import app.skerry.ui.design.folderNames
  */
 const val RUNBOOK_FOLDER_SCOPE = "runbook"
 
+/** Technical key of the "all runbooks" chip at the start of the filter row. */
+const val ALL_RUNBOOKS_CHIP = "All"
+
+/** A runbook section: group name plus its runbooks. */
+@Immutable
+data class RunbookCategory(val name: String, val runbooks: List<RunbookEntry>)
+
 /** Folders the library already uses — what the editor's "Group" select offers. */
 fun runbookFolders(runbooks: List<RunbookEntry>): List<String> =
     folderNames(runbooks.map { it.runbook.group })
+
+/** Chip label for display in library (tags): localized for the two technical keys, otherwise tag label (#tag). */
+@Composable
+fun runbookChipLabel(chip: String): String = when (chip) {
+    ALL_RUNBOOKS_CHIP -> stringResource(Res.string.lib_snippets_chip_all)
+    UNGROUPED_FOLDER -> uncategorizedSnippetsLabel()
+    else -> tagChipLabel(chip)
+}
+
+/** Chip label for display in palettes/drawers (group folders): localized for the two technical keys, otherwise folder label. */
+@Composable
+fun runbookGroupChipLabel(chip: String): String = when (chip) {
+    ALL_RUNBOOKS_CHIP -> stringResource(Res.string.lib_snippets_chip_all)
+    UNGROUPED_FOLDER -> uncategorizedSnippetsLabel()
+    else -> folderLabel(chip)
+}
+
+/**
+ * Group runbooks into sections by folder/group ([foldersOf]).
+ */
+fun groupRunbooksByCategory(runbooks: List<RunbookEntry>): List<RunbookCategory> {
+    val folders = foldersOf(runbooks) { it.runbook.group }
+    return folders.map { RunbookCategory(it.name, it.items) }
+}
+
+/**
+ * Whether anything is filed in a folder at all in the runbooks.
+ */
+fun hasRunbookCategories(runbooks: List<RunbookEntry>): Boolean =
+    hasFolders(runbooks) { it.runbook.group }
+
+/**
+ * Unique tags present in [runbooks] in alphabetical order.
+ */
+fun runbookTags(runbooks: List<RunbookEntry>): List<String> =
+    runbooks.flatMap { it.runbook.tags }.distinct().sorted()
+
+/**
+ * Filter chips for runbook group folders.
+ */
+fun runbookCategoryChips(runbooks: List<RunbookEntry>): List<String> {
+    val tags = runbookTags(runbooks)
+    val hasUntagged = runbooks.any { it.runbook.tags.isEmpty() }
+    return buildList {
+        add(ALL_RUNBOOKS_CHIP)
+        addAll(tags)
+        if (hasUntagged) add(UNCATEGORIZED_KEY)
+    }
+}
+
+/**
+ * Group chips for the palette/drawer: `All`, plus the group folders in [groupRunbooksByCategory] order.
+ */
+fun runbookGroupChips(runbooks: List<RunbookEntry>): List<String> =
+    listOf(ALL_RUNBOOKS_CHIP) + groupRunbooksByCategory(runbooks).map { it.name }
+
+/**
+ * Filter runbooks by active chip and search query.
+ */
+fun filterRunbooks(
+    runbooks: List<RunbookEntry>,
+    activeChip: String = ALL_RUNBOOKS_CHIP,
+    query: String = "",
+): List<RunbookEntry> {
+    val q = query.trim().lowercase()
+    return runbooks.filter { entry ->
+        val matchesQuery = q.isEmpty() || entry.matches(q)
+        val matchesChip = when (activeChip) {
+            ALL_RUNBOOKS_CHIP -> true
+            UNGROUPED_FOLDER -> entry.runbook.group.isNullOrBlank()
+            else -> entry.runbook.group?.equals(activeChip, ignoreCase = true) == true || activeChip in entry.runbook.tags
+        }
+        matchesQuery && matchesChip
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookManager.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookManager.kt
@@ -83,8 +83,42 @@ class RunbookManager(
         )
         store.put(runbook)
         val existing = find(id)
-        if (existing != null) existing.runbook = runbook else runbooks = runbooks + RunbookEntry(runbook)
+        if (existing != null) {
+            existing.runbook = runbook
+            runbooks = runbooks.map { if (it.id == id) RunbookEntry(runbook) else it }
+        } else {
+            runbooks = runbooks + RunbookEntry(runbook)
+        }
         return id
+    }
+
+    /** Move runbook [runbookId] to [targetGroup] at [targetIndexInGroup]. */
+    fun moveRunbook(runbookId: String, targetGroup: String?, targetIndexInGroup: Int) {
+        moveRunbooks(setOf(runbookId), targetGroup, targetIndexInGroup)
+    }
+
+    /** Move multiple runbooks [runbookIds] to [targetGroup] at [targetIndexInGroup]. */
+    fun moveRunbooks(runbookIds: Set<String>, targetGroup: String?, targetIndexInGroup: Int) {
+        store.reorder { moveRunbooksToGroup(it, runbookIds, targetGroup, targetIndexInGroup) }
+        runbooks = store.all().map { RunbookEntry(it.canonical()) }
+    }
+
+    /** Move folder [group] to [targetGroupIndex] among folders. */
+    fun moveGroup(group: String?, targetGroupIndex: Int) {
+        store.reorder { moveRunbookGroup(it, group, targetGroupIndex) }
+        runbooks = store.all().map { RunbookEntry(it.canonical()) }
+    }
+
+    /** Rename group [oldName] to [newName] across all runbooks. */
+    fun renameGroup(oldName: String, newName: String) {
+        store.reorder { renameRunbookGroup(it, oldName, newName) }
+        runbooks = store.all().map { RunbookEntry(it.canonical()) }
+    }
+
+    /** Delete group [name]: ungroups its runbooks, setting group to null (items are kept). */
+    fun deleteGroup(name: String) {
+        store.reorder { renameRunbookGroup(it, name, null) }
+        runbooks = store.all().map { RunbookEntry(it.canonical()) }
     }
 
     /** Delete a runbook: remove it from the store and the list. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookReordering.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookReordering.kt
@@ -1,0 +1,82 @@
+package app.skerry.ui.runbook
+
+import app.skerry.shared.runbook.Runbook
+import app.skerry.shared.text.normalizeGroup
+
+/**
+ * Move runbooks [movingIds] into group [targetGroup] at [targetIndexInGroup] among its runbooks.
+ * Preserves the original relative order among [movingIds].
+ */
+fun moveRunbooksToGroup(
+    runbooks: List<Runbook>,
+    movingIds: Set<String>,
+    targetGroup: String?,
+    targetIndexInGroup: Int,
+): List<Runbook> {
+    if (movingIds.isEmpty()) return runbooks
+    val moving = runbooks.filter { it.id in movingIds }
+    if (moving.isEmpty()) return runbooks
+    val canonicalTarget = normalizeGroup(targetGroup)
+    val buckets = LinkedHashMap<String?, MutableList<Runbook>>()
+    for (r in runbooks) {
+        if (r.id in movingIds) continue
+        buckets.getOrPut(normalizeGroup(r.group)) { mutableListOf() }.add(r)
+    }
+    val target = buckets.getOrPut(canonicalTarget) { mutableListOf() }
+    val insertionIndex = targetIndexInGroup.coerceIn(0, target.size)
+    val updatedMoving = moving.map { it.copy(group = canonicalTarget) }
+    target.addAll(insertionIndex, updatedMoving)
+    return buckets.values.flatten()
+}
+
+/**
+ * Move runbook [runbookId] into group [targetGroup] at [targetIndexInGroup] among its runbooks.
+ * Covers both drag scenarios: reordering within a folder ([targetGroup] == current group) and
+ * moving to another (rewriting [Runbook.group]).
+ */
+fun moveRunbookToGroup(
+    runbooks: List<Runbook>,
+    runbookId: String,
+    targetGroup: String?,
+    targetIndexInGroup: Int,
+): List<Runbook> = moveRunbooksToGroup(runbooks, setOf(runbookId), targetGroup, targetIndexInGroup)
+
+/**
+ * Move folder [group] as a whole to [targetGroupIndex] among folders (runbook order within it is
+ * preserved). Index is clamped; unknown [group] leaves the list unchanged.
+ */
+fun moveRunbookGroup(runbooks: List<Runbook>, group: String?, targetGroupIndex: Int): List<Runbook> {
+    val canonical = normalizeGroup(group)
+    val buckets = LinkedHashMap<String?, MutableList<Runbook>>()
+    for (r in runbooks) {
+        buckets.getOrPut(normalizeGroup(r.group)) { mutableListOf() }.add(r)
+    }
+    val keys = buckets.keys.toMutableList()
+    val from = keys.indexOf(canonical)
+    if (from < 0) return runbooks
+    keys.removeAt(from)
+    keys.add(targetGroupIndex.coerceIn(0, keys.size), canonical)
+    return keys.flatMap { buckets.getValue(it) }
+}
+
+/**
+ * Rename group [oldName] to [newName] across all runbooks.
+ * Blank/null [newName] ungroups the runbooks (`Runbook.group = null`), which is also how a group is deleted.
+ */
+fun renameRunbookGroup(
+    runbooks: List<Runbook>,
+    oldName: String?,
+    newName: String?,
+): List<Runbook> {
+    val canonicalOld = normalizeGroup(oldName) ?: return runbooks
+    val canonicalNew = normalizeGroup(newName)
+    if (canonicalOld == canonicalNew) return runbooks
+    val buckets = LinkedHashMap<String?, MutableList<Runbook>>()
+    for (r in runbooks) {
+        val group = normalizeGroup(r.group)
+        val updatedGroup = if (group == canonicalOld) canonicalNew else group
+        val updated = if (group == canonicalOld) r.copy(group = canonicalNew) else r
+        buckets.getOrPut(updatedGroup) { mutableListOf() }.add(updated)
+    }
+    return buckets.values.flatten()
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetGrouping.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetGrouping.kt
@@ -2,23 +2,25 @@ package app.skerry.ui.snippet
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import app.skerry.ui.design.UNGROUPED_FOLDER
+import app.skerry.ui.design.folderLabel
+import app.skerry.ui.design.folderNames
+import app.skerry.ui.design.foldersOf
+import app.skerry.ui.design.hasFolders
+import app.skerry.ui.design.tagChipLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_chip_all
 import app.skerry.ui.generated.resources.lib_snippets_uncategorized
 import org.jetbrains.compose.resources.stringResource
-import app.skerry.ui.design.folderNames
-import app.skerry.ui.design.tagChipLabel
 
-/** A snippet library section: category name plus its snippets (in source list order). */
+/** A snippet library section: group name plus its snippets (in source list order). */
 @Immutable
 data class SnippetCategory(val name: String, val snippets: List<SnippetEntry>)
 
 /**
- * Technical key for the synthetic bucket holding snippets without tags. Used as the grouping key in
- * [groupSnippetsByCategory] and as a filter chip value; not localized, since that would break
- * grouping and filtering on locale change. For display, use [uncategorizedSnippetsLabel].
+ * Technical key for the synthetic bucket holding unfiled snippets.
  */
-const val UNCATEGORIZED_KEY = "Uncategorized"
+const val UNCATEGORIZED_KEY = UNGROUPED_FOLDER
 
 /** Technical key of the "all snippets" chip at the start of the library filter row. */
 const val ALL_SNIPPETS_CHIP = "All"
@@ -34,51 +36,66 @@ const val SNIPPET_FOLDER_SCOPE = "snippet"
 fun snippetFolders(snippets: List<SnippetEntry>): List<String> =
     folderNames(snippets.map { it.snippet.group })
 
-/** Localized "uncategorized" bucket label for display (not for grouping, see [UNCATEGORIZED_KEY]). */
+/** Localized "uncategorized" bucket label for display. */
 @Composable
 fun uncategorizedSnippetsLabel(): String = stringResource(Res.string.lib_snippets_uncategorized)
 
-/** Chip label for display: localized for the two technical keys, `#tag` for a real category. */
+/** Chip label for display in library (tags): localized for the two technical keys, otherwise tag label (#tag). */
 @Composable
 fun snippetChipLabel(chip: String): String = when (chip) {
     ALL_SNIPPETS_CHIP -> stringResource(Res.string.lib_snippets_chip_all)
-    UNCATEGORIZED_KEY -> uncategorizedSnippetsLabel()
+    UNGROUPED_FOLDER -> uncategorizedSnippetsLabel()
     else -> tagChipLabel(chip)
 }
 
+/** Chip label for display in palettes/drawers (group folders): localized for the two technical keys, otherwise folder label. */
+@Composable
+fun snippetGroupChipLabel(chip: String): String = when (chip) {
+    ALL_SNIPPETS_CHIP -> stringResource(Res.string.lib_snippets_chip_all)
+    UNGROUPED_FOLDER -> uncategorizedSnippetsLabel()
+    else -> folderLabel(chip)
+}
+
 /**
- * Group snippets into library sections by tag. Unlike host folders ([app.skerry.ui.host.HostFolder]),
- * a snippet carries several tags and therefore appears in every matching section — so sections are
- * ordered alphabetically rather than by first appearance, which would be arbitrary here. Tags are
- * canonical (lowercase, see [parseSnippetTags]), so the sort is a plain string comparison. Untagged
- * snippets land in the [UNCATEGORIZED_KEY] bucket, kept last. Snippets keep source order inside a
+ * Group snippets into library sections by folder/group ([foldersOf]). Untagged/unfiled
+ * snippets land in the [UNGROUPED_FOLDER] bucket, kept last. Snippets keep source order inside a
  * section. Pure function (no Compose), shared by desktop and mobile.
  */
 fun groupSnippetsByCategory(snippets: List<SnippetEntry>): List<SnippetCategory> {
-    val buckets = sortedMapOf<String, MutableList<SnippetEntry>>()
-    val uncategorized = mutableListOf<SnippetEntry>()
-    for (entry in snippets) {
-        val tags = entry.snippet.tags
-        if (tags.isEmpty()) uncategorized += entry
-        else for (tag in tags) buckets.getOrPut(tag) { mutableListOf() }.add(entry)
-    }
+    val folders = foldersOf(snippets) { it.snippet.group }
+    return folders.map { SnippetCategory(it.name, it.items) }
+}
+
+/**
+ * Whether anything is filed in a folder at all.
+ */
+fun hasCategories(snippets: List<SnippetEntry>): Boolean =
+    hasFolders(snippets) { it.snippet.group }
+
+/**
+ * Unique tags present in [snippets] in alphabetical order.
+ */
+fun snippetTags(snippets: List<SnippetEntry>): List<String> =
+    snippets.flatMap { it.snippet.tags }.distinct().sorted()
+
+/**
+ * Filter chips for the snippet library: `All`, unique tags in alphabetical order, and
+ * [UNCATEGORIZED_KEY] if anything is untagged.
+ */
+fun snippetCategoryChips(snippets: List<SnippetEntry>): List<String> {
+    val tags = snippetTags(snippets)
+    val hasUntagged = snippets.any { it.snippet.tags.isEmpty() }
     return buildList {
-        buckets.forEach { (name, list) -> add(SnippetCategory(name, list)) }
-        if (uncategorized.isNotEmpty()) add(SnippetCategory(UNCATEGORIZED_KEY, uncategorized))
+        add(ALL_SNIPPETS_CHIP)
+        addAll(tags)
+        if (hasUntagged) add(UNCATEGORIZED_KEY)
     }
 }
 
 /**
- * Whether anything is tagged at all. With no tags the library renders as a flat list: chips and
- * section headers would be pure chrome around a single "Uncategorized" bucket.
+ * Group chips for the palette/drawer: `All`, plus the group folders in [groupSnippetsByCategory] order.
  */
-fun hasCategories(snippets: List<SnippetEntry>): Boolean = snippets.any { it.snippet.tags.isNotEmpty() }
-
-/**
- * Filter chips: `All`, then the categories in the same order [groupSnippetsByCategory] renders them.
- * The uncategorized chip appears only when something is actually untagged.
- */
-fun snippetCategoryChips(snippets: List<SnippetEntry>): List<String> =
+fun snippetGroupChips(snippets: List<SnippetEntry>): List<String> =
     listOf(ALL_SNIPPETS_CHIP) + groupSnippetsByCategory(snippets).map { it.name }
 
 /** Case-insensitive search across a snippet's name, command, folder, tags and notes. */
@@ -92,7 +109,7 @@ fun SnippetEntry.matches(query: String): Boolean {
 }
 
 /**
- * Narrow [snippets] by the active chip ([activeChip] = category, `All` = no filter) and [query] (AND).
+ * Narrow [snippets] by the active chip ([activeChip] = tag or group name, `All` = no filter) and [query] (AND).
  * Search is case-insensitive across label/command/tags/notes (see [SnippetEntry.matches]).
  */
 fun filterSnippets(
@@ -102,8 +119,8 @@ fun filterSnippets(
 ): List<SnippetEntry> = snippets.filter { entry ->
     val chipOk = when (activeChip) {
         ALL_SNIPPETS_CHIP -> true
-        UNCATEGORIZED_KEY -> entry.snippet.tags.isEmpty()
-        else -> activeChip in entry.snippet.tags
+        UNGROUPED_FOLDER -> entry.snippet.group.isNullOrBlank()
+        else -> entry.snippet.group?.equals(activeChip, ignoreCase = true) == true || activeChip in entry.snippet.tags
     }
     chipOk && (query.isBlank() || entry.matches(query))
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetManager.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetManager.kt
@@ -141,8 +141,42 @@ class SnippetManager(
         )
         store.put(snippet)
         val existing = find(id)
-        if (existing != null) existing.snippet = snippet else snippets = snippets + SnippetEntry(snippet)
+        if (existing != null) {
+            existing.snippet = snippet
+            snippets = snippets.map { if (it.id == id) SnippetEntry(snippet) else it }
+        } else {
+            snippets = snippets + SnippetEntry(snippet)
+        }
         return id
+    }
+
+    /** Move snippet [snippetId] to [targetGroup] at [targetIndexInGroup]. */
+    fun moveSnippet(snippetId: String, targetGroup: String?, targetIndexInGroup: Int) {
+        moveSnippets(setOf(snippetId), targetGroup, targetIndexInGroup)
+    }
+
+    /** Move multiple snippets [snippetIds] to [targetGroup] at [targetIndexInGroup]. */
+    fun moveSnippets(snippetIds: Set<String>, targetGroup: String?, targetIndexInGroup: Int) {
+        store.reorder { moveSnippetsToGroup(it, snippetIds, targetGroup, targetIndexInGroup) }
+        snippets = store.all().map { SnippetEntry(it.canonical()) }
+    }
+
+    /** Move folder [group] to [targetGroupIndex] among folders. */
+    fun moveGroup(group: String?, targetGroupIndex: Int) {
+        store.reorder { moveSnippetGroup(it, group, targetGroupIndex) }
+        snippets = store.all().map { SnippetEntry(it.canonical()) }
+    }
+
+    /** Rename group [oldName] to [newName] across all snippets. */
+    fun renameGroup(oldName: String, newName: String) {
+        store.reorder { renameSnippetGroup(it, oldName, newName) }
+        snippets = store.all().map { SnippetEntry(it.canonical()) }
+    }
+
+    /** Delete group [name]: ungroups its snippets, setting group to null (items are kept). */
+    fun deleteGroup(name: String) {
+        store.reorder { renameSnippetGroup(it, name, null) }
+        snippets = store.all().map { SnippetEntry(it.canonical()) }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetReordering.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetReordering.kt
@@ -1,0 +1,82 @@
+package app.skerry.ui.snippet
+
+import app.skerry.shared.snippet.Snippet
+import app.skerry.shared.text.normalizeGroup
+
+/**
+ * Move snippets [movingIds] into group [targetGroup] at [targetIndexInGroup] among its snippets.
+ * Preserves the original relative order among [movingIds].
+ */
+fun moveSnippetsToGroup(
+    snippets: List<Snippet>,
+    movingIds: Set<String>,
+    targetGroup: String?,
+    targetIndexInGroup: Int,
+): List<Snippet> {
+    if (movingIds.isEmpty()) return snippets
+    val moving = snippets.filter { it.id in movingIds }
+    if (moving.isEmpty()) return snippets
+    val canonicalTarget = normalizeGroup(targetGroup)
+    val buckets = LinkedHashMap<String?, MutableList<Snippet>>()
+    for (s in snippets) {
+        if (s.id in movingIds) continue
+        buckets.getOrPut(normalizeGroup(s.group)) { mutableListOf() }.add(s)
+    }
+    val target = buckets.getOrPut(canonicalTarget) { mutableListOf() }
+    val insertionIndex = targetIndexInGroup.coerceIn(0, target.size)
+    val updatedMoving = moving.map { it.copy(group = canonicalTarget) }
+    target.addAll(insertionIndex, updatedMoving)
+    return buckets.values.flatten()
+}
+
+/**
+ * Move snippet [snippetId] into group [targetGroup] at [targetIndexInGroup] among its snippets.
+ * Covers both drag scenarios: reordering within a folder ([targetGroup] == current group) and
+ * moving to another (rewriting [Snippet.group]).
+ */
+fun moveSnippetToGroup(
+    snippets: List<Snippet>,
+    snippetId: String,
+    targetGroup: String?,
+    targetIndexInGroup: Int,
+): List<Snippet> = moveSnippetsToGroup(snippets, setOf(snippetId), targetGroup, targetIndexInGroup)
+
+/**
+ * Move folder [group] as a whole to [targetGroupIndex] among folders (snippet order within it is
+ * preserved). Index is clamped; unknown [group] leaves the list unchanged.
+ */
+fun moveSnippetGroup(snippets: List<Snippet>, group: String?, targetGroupIndex: Int): List<Snippet> {
+    val canonical = normalizeGroup(group)
+    val buckets = LinkedHashMap<String?, MutableList<Snippet>>()
+    for (s in snippets) {
+        buckets.getOrPut(normalizeGroup(s.group)) { mutableListOf() }.add(s)
+    }
+    val keys = buckets.keys.toMutableList()
+    val from = keys.indexOf(canonical)
+    if (from < 0) return snippets
+    keys.removeAt(from)
+    keys.add(targetGroupIndex.coerceIn(0, keys.size), canonical)
+    return keys.flatMap { buckets.getValue(it) }
+}
+
+/**
+ * Rename group [oldName] to [newName] across all snippets.
+ * Blank/null [newName] ungroups the snippets (`Snippet.group = null`), which is also how a group is deleted.
+ */
+fun renameSnippetGroup(
+    snippets: List<Snippet>,
+    oldName: String?,
+    newName: String?,
+): List<Snippet> {
+    val canonicalOld = normalizeGroup(oldName) ?: return snippets
+    val canonicalNew = normalizeGroup(newName)
+    if (canonicalOld == canonicalNew) return snippets
+    val buckets = LinkedHashMap<String?, MutableList<Snippet>>()
+    for (s in snippets) {
+        val group = normalizeGroup(s.group)
+        val updatedGroup = if (group == canonicalOld) canonicalNew else group
+        val updated = if (group == canonicalOld) s.copy(group = canonicalNew) else s
+        buckets.getOrPut(updatedGroup) { mutableListOf() }.add(updated)
+    }
+    return buckets.values.flatten()
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
@@ -208,14 +208,32 @@ internal fun HostRow(
 /** Cyan indicator line marking where a dragged host/folder will be inserted. */
 @Composable
 internal fun DropLine() {
-    Box(
+    Row(
         Modifier
             .fillMaxWidth()
-            .padding(end = 8.dp, top = 2.dp, bottom = 2.dp)
-            .height(2.dp)
-            .clip(RoundedCornerShape(1.dp))
-            .background(Skerry.colors.cyan),
-    )
+            .padding(end = 8.dp, top = 2.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            Modifier
+                .size(5.dp)
+                .clip(RoundedCornerShape(2.5.dp))
+                .background(Skerry.colors.cyanBright)
+        )
+        Box(
+            Modifier
+                .weight(1f)
+                .height(3.dp)
+                .clip(RoundedCornerShape(1.5.dp))
+                .background(Skerry.colors.cyan)
+        )
+        Box(
+            Modifier
+                .size(5.dp)
+                .clip(RoundedCornerShape(2.5.dp))
+                .background(Skerry.colors.cyanBright)
+        )
+    }
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebarSections.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebarSections.kt
@@ -303,9 +303,11 @@ internal fun LiveHostFolder(
     // Edit pencil in the header, except for the synthetic "Ungrouped" bucket (not renameable).
     val onEditGroup = if (folder.name == UNGROUPED_LABEL) null
         else remember(state, folder.name) { { state.openRenameGroup(folder.name) } }
+    val isAnyFolderDragging = dragState.draggingFolderName != null
+    val isThisFolderDragging = dragState.draggingFolderName == folder.name
     // Highlights the target folder while a host is dragged over it.
     val isDropTarget = dragState.draggingHostId != null && dragState.activeHostDrop?.group == group
-    val folderAlpha = if (dragState.draggingFolderName == folder.name) 0.4f else 1f
+    val folderAlpha = if (isThisFolderDragging) 0.6f else 1f
     // Insertion line within the folder: the index excludes the dragged host (like moveHostToGroup),
     // so it's anchored to visible rows via neighbors from the same filtered list.
     val others = folder.hosts.filter { it.id != dragState.draggingHostId }
@@ -315,16 +317,35 @@ internal fun LiveHostFolder(
         Modifier
             .padding(bottom = 2.dp)
             .alpha(folderAlpha)
-            .clip(RoundedCornerShape(6.dp))
-            // After clip, so bounds match the folder's visible (rounded) area, not its corners.
-            .folderRangeAnchor(dragState, folder.name)
-            .border(1.dp, if (isDropTarget) Skerry.colors.cyan else Color.Transparent, RoundedCornerShape(6.dp)),
+            .folderRangeAnchor(dragState, folder.name),
     ) {
         Box(
-            Modifier.folderHeaderAnchor(dragState, folder.name)
+            Modifier
+                .clip(RoundedCornerShape(6.dp))
+                .background(
+                    when {
+                        isThisFolderDragging -> Skerry.colors.card
+                        isDropTarget -> Skerry.colors.cyan.copy(alpha = 0.12f)
+                        else -> Color.Transparent
+                    }
+                )
+                .border(
+                    1.dp,
+                    when {
+                        isThisFolderDragging -> Skerry.colors.cyan
+                        isDropTarget -> Skerry.colors.cyanBright
+                        else -> Color.Transparent
+                    },
+                    RoundedCornerShape(6.dp)
+                )
+                .folderHeaderAnchor(dragState, folder.name)
                 // Section-aware: the drop index counts the folders this sidebar shows, not the
                 // catalog's (a folder of the other section is invisible here and keeps its place).
-                .draggableFolderHeader(dragState, folder.name, foldersProvider) { index ->
+                .draggableFolderHeader(
+                    state = dragState,
+                    name = folder.name,
+                    folders = foldersProvider,
+                ) { index ->
                     controller.moveFolderInSection(group, index, section)
                 },
         ) {
@@ -332,8 +353,9 @@ internal fun LiveHostFolder(
             val headerName = if (folder.name == UNGROUPED_LABEL) ungroupedLabel() else folder.name
             FolderHeader(headerName, folder.hosts.size, collapsed, onToggleCollapsed, onEditGroup)
         }
-        // A collapsed folder shows only the header; the host list (and its drag targets) is hidden.
-        if (!collapsed) Column(Modifier.padding(start = 22.dp)) {
+        // A collapsed folder shows only the header; when any folder is dragged, all folders
+        // temporarily collapse to allow fast, compact and predictable folder reordering.
+        if (!collapsed && !isAnyFolderDragging) Column(Modifier.padding(start = 22.dp)) {
             if (folder.name == UNGROUPED_LABEL) {
                 // No-group bucket: sub-group by connection type with a small header per transport.
                 // Reorder insertion lines are dropped here (ordering a typeless bucket is moot); a

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/design/FoldersTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/design/FoldersTest.kt
@@ -13,7 +13,7 @@ class FoldersTest {
     private fun folders(vararg rows: Row) = foldersOf(rows.toList()) { it.group }
 
     @Test
-    fun named_folders_come_first_alphabetically_and_ungrouped_last() {
+    fun named_folders_appear_in_source_order_and_ungrouped_last() {
         val result = folders(
             Row("a", "staging"),
             Row("b", null),
@@ -21,16 +21,17 @@ class FoldersTest {
             Row("d", "staging"),
         )
 
-        assertEquals(listOf("Production", "staging", UNGROUPED_FOLDER), result.map { it.name })
-        assertEquals(listOf("a", "d"), result[1].items.map { it.id })
+        assertEquals(listOf("staging", "Production", UNGROUPED_FOLDER), result.map { it.name })
+        assertEquals(listOf("a", "d"), result[0].items.map { it.id })
+        assertEquals(listOf("c"), result[1].items.map { it.id })
         assertEquals(listOf("b"), result[2].items.map { it.id })
     }
 
     @Test
-    fun sorting_is_case_insensitive_so_a_lowercase_folder_is_not_exiled_to_the_end() {
+    fun folders_preserve_order_of_first_appearance() {
         val result = folders(Row("a", "zebra"), Row("b", "Alpha"), Row("c", "beta"))
 
-        assertEquals(listOf("Alpha", "beta", "zebra"), result.map { it.name })
+        assertEquals(listOf("zebra", "Alpha", "beta"), result.map { it.name })
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookGroupingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookGroupingTest.kt
@@ -2,6 +2,8 @@ package app.skerry.ui.runbook
 
 import app.skerry.shared.runbook.Runbook
 import app.skerry.shared.runbook.RunbookStep
+import app.skerry.ui.design.UNGROUPED_FOLDER
+import app.skerry.ui.snippet.UNCATEGORIZED_KEY
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -9,11 +11,12 @@ import kotlin.test.assertTrue
 
 class RunbookGroupingTest {
 
-    private fun entry(label: String, group: String? = null) = RunbookEntry(
+    private fun entry(label: String, group: String? = null, tags: List<String> = emptyList()) = RunbookEntry(
         Runbook(
             id = label,
             label = label,
             steps = listOf(RunbookStep.Command(id = "s1", command = "uptime")),
+            tags = tags,
             group = group,
         ),
     )
@@ -30,5 +33,51 @@ class RunbookGroupingTest {
         val all = listOf(entry("A", "staging"), entry("B"), entry("C", "Prod"), entry("D", "staging"))
 
         assertEquals(listOf("Prod", "staging"), runbookFolders(all))
+    }
+
+    @Test
+    fun groups_runbooks_by_folder() {
+        val all = listOf(
+            entry("Backup", group = "db"),
+            entry("Deploy", group = "ops"),
+            entry("Unfiled"),
+        )
+        val groups = groupRunbooksByCategory(all)
+        assertEquals(3, groups.size)
+        assertEquals("db", groups[0].name)
+        assertEquals(1, groups[0].runbooks.size)
+        assertEquals("ops", groups[1].name)
+        assertEquals(1, groups[1].runbooks.size)
+        assertEquals(UNGROUPED_FOLDER, groups[2].name)
+        assertEquals(1, groups[2].runbooks.size)
+    }
+
+    @Test
+    fun chips_are_all_plus_sorted_unique_tags() {
+        val chips = runbookCategoryChips(
+            listOf(entry("a", tags = listOf("net", "disk")), entry("b", tags = listOf("disk")), entry("c")),
+        )
+
+        assertEquals(listOf(ALL_RUNBOOKS_CHIP, "disk", "net", UNCATEGORIZED_KEY), chips)
+    }
+
+    @Test
+    fun group_chips_are_all_plus_unique_folders_in_source_order() {
+        val chips = runbookGroupChips(
+            listOf(entry("a", group = "net"), entry("b", group = "disk"), entry("c")),
+        )
+
+        assertEquals(listOf(ALL_RUNBOOKS_CHIP, "net", "disk", UNGROUPED_FOLDER), chips)
+    }
+
+    @Test
+    fun filter_runbooks_by_chip_and_query() {
+        val all = listOf(
+            entry("Backup", group = "ops"),
+            entry("Deploy", group = "release"),
+        )
+        assertEquals(1, filterRunbooks(all, activeChip = "ops").size)
+        assertEquals("Backup", filterRunbooks(all, activeChip = "ops")[0].runbook.label)
+        assertEquals(1, filterRunbooks(all, query = "deploy").size)
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookManagerTest.kt
@@ -16,6 +16,11 @@ class RunbookManagerTest {
         override fun all(): List<Runbook> = items.values.toList()
         override fun put(runbook: Runbook) { items[runbook.id] = runbook }
         override fun remove(id: String) { items.remove(id) }
+        override fun reorder(transform: (List<Runbook>) -> List<Runbook>) {
+            val updated = transform(all())
+            items.clear()
+            updated.forEach { items[it.id] = it }
+        }
     }
 
     private fun manager(store: RunbookStore = MemoryStore()): RunbookManager {
@@ -142,5 +147,40 @@ class RunbookManagerTest {
         assertTrue(m.runbooks.isEmpty())
         m.reload()
         assertEquals(listOf("Synced"), m.runbooks.map { it.runbook.label })
+    }
+
+    @Test
+    fun `renameGroup updates group across runbooks`() {
+        val m = manager()
+        m.save(draft("R1", "uptime").copy(group = "Deploy"))
+        m.save(draft("R2", "uptime").copy(group = "Deploy"))
+        m.save(draft("R3", "uptime").copy(group = "Backup"))
+
+        m.renameGroup("Deploy", "Deployment")
+
+        assertEquals(listOf("Deployment", "Deployment", "Backup"), m.runbooks.map { it.runbook.group })
+    }
+
+    @Test
+    fun `deleteGroup ungroups runbooks without deleting them`() {
+        val m = manager()
+        m.save(draft("R1", "uptime").copy(group = "Deploy"))
+        m.save(draft("R2", "uptime").copy(group = "Backup"))
+
+        m.deleteGroup("Deploy")
+
+        assertEquals(null, m.runbooks.first { it.runbook.label == "R1" }.runbook.group)
+        assertEquals("Backup", m.runbooks.first { it.runbook.label == "R2" }.runbook.group)
+    }
+
+    @Test
+    fun `moveRunbook reorders and persists`() {
+        val m = manager()
+        val r1 = m.save(draft("R1", "uptime").copy(group = "Deploy"))
+        val r2 = m.save(draft("R2", "uptime").copy(group = "Deploy"))
+
+        m.moveRunbook(r2, "Deploy", 0)
+
+        assertEquals(listOf(r2, r1), m.runbooks.map { it.id })
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookReorderingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookReorderingTest.kt
@@ -1,0 +1,107 @@
+package app.skerry.ui.runbook
+
+import app.skerry.shared.runbook.Runbook
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RunbookReorderingTest {
+
+    private fun runbook(id: String, group: String? = null) = Runbook(
+        id = id,
+        label = "Runbook $id",
+        group = group,
+    )
+
+    @Test
+    fun `moveRunbookToGroup reorders within the same group`() {
+        val runbooks = listOf(
+            runbook("r1", "Deploy"),
+            runbook("r2", "Deploy"),
+            runbook("r3", "Deploy"),
+        )
+        val result = moveRunbookToGroup(runbooks, runbookId = "r3", targetGroup = "Deploy", targetIndexInGroup = 0)
+        assertEquals(listOf("r3", "r1", "r2"), result.map { it.id })
+    }
+
+    @Test
+    fun `moveRunbookToGroup moves item to another group`() {
+        val runbooks = listOf(
+            runbook("r1", "Deploy"),
+            runbook("r2", "Deploy"),
+            runbook("r3", "Backup"),
+        )
+        val result = moveRunbookToGroup(runbooks, runbookId = "r3", targetGroup = "Deploy", targetIndexInGroup = 1)
+        assertEquals(listOf("r1", "r3", "r2"), result.map { it.id })
+        assertEquals("Deploy", result.first { it.id == "r3" }.group)
+    }
+
+    @Test
+    fun `moveRunbookToGroup moves item to ungrouped`() {
+        val runbooks = listOf(
+            runbook("r1", "Deploy"),
+            runbook("r2", "Deploy"),
+        )
+        val result = moveRunbookToGroup(runbooks, runbookId = "r1", targetGroup = null, targetIndexInGroup = 0)
+        assertEquals(listOf("r2", "r1"), result.map { it.id })
+        assertEquals(null, result.first { it.id == "r1" }.group)
+    }
+
+    @Test
+    fun `moveRunbooksToGroup batch moves multiple items preserving order`() {
+        val runbooks = listOf(
+            runbook("r1", "Deploy"),
+            runbook("r2", "Deploy"),
+            runbook("r3", "Backup"),
+            runbook("r4", "Backup"),
+            runbook("r5", "Backup"),
+        )
+        val result = moveRunbooksToGroup(
+            runbooks,
+            movingIds = setOf("r3", "r5"),
+            targetGroup = "Deploy",
+            targetIndexInGroup = 1,
+        )
+        assertEquals(listOf("r1", "r3", "r5", "r2", "r4"), result.map { it.id })
+        assertEquals("Deploy", result.first { it.id == "r3" }.group)
+        assertEquals("Deploy", result.first { it.id == "r5" }.group)
+        assertEquals("Backup", result.first { it.id == "r4" }.group)
+    }
+
+    @Test
+    fun `renameRunbookGroup renames group across runbooks`() {
+        val runbooks = listOf(
+            runbook("r1", "Deploy"),
+            runbook("r2", "Deploy"),
+            runbook("r3", "Backup"),
+        )
+        val result = renameRunbookGroup(runbooks, oldName = "Deploy", newName = "Deployment")
+        assertEquals(listOf("Deployment", "Deployment", "Backup"), result.map { it.group })
+        assertEquals(listOf("r1", "r2", "r3"), result.map { it.id })
+    }
+
+    @Test
+    fun `renameRunbookGroup ungroups when newName is blank`() {
+        val runbooks = listOf(
+            runbook("r1", "Deploy"),
+            runbook("r2", "Backup"),
+        )
+        val result = renameRunbookGroup(runbooks, oldName = "Deploy", newName = "")
+        assertEquals(null, result.first { it.id == "r1" }.group)
+        assertEquals("Backup", result.first { it.id == "r2" }.group)
+    }
+
+    @Test
+    fun `moveRunbookGroup reorders whole folder blocks`() {
+        val runbooks = listOf(
+            runbook("r1", "Alpha"),
+            runbook("r2", "Alpha"),
+            runbook("r3", "Beta"),
+            runbook("r4", "Gamma"),
+        )
+        val result = moveRunbookGroup(runbooks, group = "Gamma", targetGroupIndex = 0)
+        assertEquals(listOf("r4", "r1", "r2", "r3"), result.map { it.id })
+
+        val result2 = moveRunbookGroup(runbooks, group = "Alpha", targetGroupIndex = 2)
+        assertEquals(listOf("r3", "r4", "r1", "r2"), result2.map { it.id })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetGroupingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetGroupingTest.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.snippet
 
 import app.skerry.shared.snippet.Snippet
+import app.skerry.ui.design.UNGROUPED_FOLDER
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -9,41 +10,33 @@ class SnippetGroupingTest {
 
     private fun entry(
         label: String,
+        group: String? = null,
         tags: List<String> = emptyList(),
         command: String = "cmd",
         notes: String? = null,
-        group: String? = null,
     ) = SnippetEntry(Snippet(id = label, label = label, command = command, tags = tags, notes = notes, group = group))
 
     @Test
-    fun groups_by_tag_in_alphabetical_order() {
+    fun groups_by_folder_in_source_order() {
         val groups = groupSnippetsByCategory(
-            listOf(entry("Disk", listOf("disk")), entry("Ports", listOf("net")), entry("Containers", listOf("docker"))),
+            listOf(entry("Disk", group = "disk"), entry("Ports", group = "net"), entry("Containers", group = "docker")),
         )
 
-        assertEquals(listOf("disk", "docker", "net"), groups.map { it.name })
+        assertEquals(listOf("disk", "net", "docker"), groups.map { it.name })
     }
 
     @Test
-    fun a_snippet_with_several_tags_lands_in_every_category() {
-        val groups = groupSnippetsByCategory(listOf(entry("Ports", listOf("net", "disk"))))
+    fun unfiled_snippets_fall_into_the_uncategorized_bucket_last() {
+        val groups = groupSnippetsByCategory(listOf(entry("Loose"), entry("Disk", group = "disk")))
 
-        assertEquals(listOf("disk", "net"), groups.map { it.name })
-        assertTrue(groups.all { it.snippets.single().snippet.label == "Ports" })
-    }
-
-    @Test
-    fun untagged_snippets_fall_into_the_uncategorized_bucket_last() {
-        val groups = groupSnippetsByCategory(listOf(entry("Loose"), entry("Disk", listOf("disk"))))
-
-        assertEquals(listOf("disk", UNCATEGORIZED_KEY), groups.map { it.name })
+        assertEquals(listOf("disk", UNGROUPED_FOLDER), groups.map { it.name })
         assertEquals("Loose", groups.last().snippets.single().snippet.label)
     }
 
     @Test
     fun keeps_source_order_inside_a_category() {
         val groups = groupSnippetsByCategory(
-            listOf(entry("B", listOf("disk")), entry("A", listOf("disk"))),
+            listOf(entry("B", group = "disk"), entry("A", group = "disk")),
         )
 
         assertEquals(listOf("B", "A"), groups.single().snippets.map { it.snippet.label })
@@ -57,7 +50,7 @@ class SnippetGroupingTest {
     @Test
     fun chips_are_all_plus_sorted_unique_tags() {
         val chips = snippetCategoryChips(
-            listOf(entry("a", listOf("net", "disk")), entry("b", listOf("disk")), entry("c")),
+            listOf(entry("a", tags = listOf("net", "disk")), entry("b", tags = listOf("disk")), entry("c")),
         )
 
         assertEquals(listOf(ALL_SNIPPETS_CHIP, "disk", "net", UNCATEGORIZED_KEY), chips)
@@ -67,28 +60,37 @@ class SnippetGroupingTest {
     fun chips_gain_the_uncategorized_entry_only_when_something_is_untagged() {
         assertEquals(
             listOf(ALL_SNIPPETS_CHIP, "disk"),
-            snippetCategoryChips(listOf(entry("a", listOf("disk")))),
+            snippetCategoryChips(listOf(entry("a", tags = listOf("disk")))),
         )
         assertEquals(
             listOf(ALL_SNIPPETS_CHIP, "disk", UNCATEGORIZED_KEY),
-            snippetCategoryChips(listOf(entry("a", listOf("disk")), entry("b"))),
+            snippetCategoryChips(listOf(entry("a", tags = listOf("disk")), entry("b"))),
         )
     }
 
     @Test
+    fun group_chips_are_all_plus_unique_folders_in_source_order() {
+        val chips = snippetGroupChips(
+            listOf(entry("a", group = "net"), entry("b", group = "disk"), entry("c")),
+        )
+
+        assertEquals(listOf(ALL_SNIPPETS_CHIP, "net", "disk", UNGROUPED_FOLDER), chips)
+    }
+
+    @Test
     fun filter_narrows_by_chip() {
-        val all = listOf(entry("Disk", listOf("disk")), entry("Ports", listOf("net")), entry("Loose"))
+        val all = listOf(entry("Disk", group = "disk"), entry("Ports", group = "net"), entry("Loose"))
 
         assertEquals(3, filterSnippets(all).size)
         assertEquals(listOf("Disk"), filterSnippets(all, activeChip = "disk").map { it.snippet.label })
-        assertEquals(listOf("Loose"), filterSnippets(all, activeChip = UNCATEGORIZED_KEY).map { it.snippet.label })
+        assertEquals(listOf("Loose"), filterSnippets(all, activeChip = UNGROUPED_FOLDER).map { it.snippet.label })
     }
 
     @Test
     fun filter_combines_chip_and_query() {
         val all = listOf(
-            entry("Disk usage", listOf("disk"), command = "df -h"),
-            entry("Disk io", listOf("net"), command = "iostat"),
+            entry("Disk usage", group = "disk", command = "df -h"),
+            entry("Disk io", group = "net", command = "iostat"),
         )
 
         assertEquals(listOf("Disk usage"), filterSnippets(all, activeChip = "disk", query = "disk").map { it.snippet.label })

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerGroupTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerGroupTest.kt
@@ -1,0 +1,68 @@
+package app.skerry.ui.snippet
+
+import app.skerry.shared.snippet.Snippet
+import app.skerry.shared.snippet.SnippetStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SnippetManagerGroupTest {
+
+    private class MemoryStore : SnippetStore {
+        val items = linkedMapOf<String, Snippet>()
+        override fun all(): List<Snippet> = items.values.toList()
+        override fun put(snippet: Snippet) { items[snippet.id] = snippet }
+        override fun remove(id: String) { items.remove(id) }
+        override fun reorder(transform: (List<Snippet>) -> List<Snippet>) {
+            val updated = transform(all())
+            items.clear()
+            updated.forEach { items[it.id] = it }
+        }
+    }
+
+    private fun manager(store: SnippetStore = MemoryStore()): SnippetManager {
+        var n = 0
+        return SnippetManager(store, newId = { "id-${++n}" })
+    }
+
+    private fun draft(label: String = "S", command: String = "echo", group: String? = null) = SnippetDraft(
+        label = label,
+        command = command,
+        tags = listOf("ops"),
+        group = group,
+    )
+
+    @Test
+    fun `renameGroup updates group across snippets and persists`() {
+        val m = manager()
+        m.save(draft(label = "S1", group = "Ops"))
+        m.save(draft(label = "S2", group = "Ops"))
+        m.save(draft(label = "S3", group = "Dev"))
+
+        m.renameGroup("Ops", "Infra")
+
+        assertEquals(listOf("Infra", "Infra", "Dev"), m.snippets.map { it.snippet.group })
+    }
+
+    @Test
+    fun `deleteGroup ungroups snippets while keeping them`() {
+        val m = manager()
+        m.save(draft(label = "S1", group = "Ops"))
+        m.save(draft(label = "S2", group = "Dev"))
+
+        m.deleteGroup("Ops")
+
+        assertEquals(null, m.snippets.first { it.snippet.label == "S1" }.snippet.group)
+        assertEquals("Dev", m.snippets.first { it.snippet.label == "S2" }.snippet.group)
+    }
+
+    @Test
+    fun `moveSnippet reorders and persists`() {
+        val m = manager()
+        val s1 = m.save(draft(label = "S1", group = "Ops"))
+        val s2 = m.save(draft(label = "S2", group = "Ops"))
+
+        m.moveSnippet(s2, "Ops", 0)
+
+        assertEquals(listOf(s2, s1), m.snippets.map { it.id })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetReorderingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetReorderingTest.kt
@@ -1,0 +1,108 @@
+package app.skerry.ui.snippet
+
+import app.skerry.shared.snippet.Snippet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SnippetReorderingTest {
+
+    private fun snippet(id: String, group: String? = null) = Snippet(
+        id = id,
+        label = "Label $id",
+        command = "echo $id",
+        group = group,
+    )
+
+    @Test
+    fun `moveSnippetToGroup reorders within the same group`() {
+        val snippets = listOf(
+            snippet("s1", "Ops"),
+            snippet("s2", "Ops"),
+            snippet("s3", "Ops"),
+        )
+        val result = moveSnippetToGroup(snippets, snippetId = "s3", targetGroup = "Ops", targetIndexInGroup = 0)
+        assertEquals(listOf("s3", "s1", "s2"), result.map { it.id })
+    }
+
+    @Test
+    fun `moveSnippetToGroup moves item to another group`() {
+        val snippets = listOf(
+            snippet("s1", "Ops"),
+            snippet("s2", "Ops"),
+            snippet("s3", "Dev"),
+        )
+        val result = moveSnippetToGroup(snippets, snippetId = "s3", targetGroup = "Ops", targetIndexInGroup = 1)
+        assertEquals(listOf("s1", "s3", "s2"), result.map { it.id })
+        assertEquals("Ops", result.first { it.id == "s3" }.group)
+    }
+
+    @Test
+    fun `moveSnippetToGroup moves item to ungrouped`() {
+        val snippets = listOf(
+            snippet("s1", "Ops"),
+            snippet("s2", "Ops"),
+        )
+        val result = moveSnippetToGroup(snippets, snippetId = "s1", targetGroup = null, targetIndexInGroup = 0)
+        assertEquals(listOf("s2", "s1"), result.map { it.id })
+        assertEquals(null, result.first { it.id == "s1" }.group)
+    }
+
+    @Test
+    fun `moveSnippetsToGroup batch moves multiple items preserving order`() {
+        val snippets = listOf(
+            snippet("s1", "Ops"),
+            snippet("s2", "Ops"),
+            snippet("s3", "Dev"),
+            snippet("s4", "Dev"),
+            snippet("s5", "Dev"),
+        )
+        val result = moveSnippetsToGroup(
+            snippets,
+            movingIds = setOf("s3", "s5"),
+            targetGroup = "Ops",
+            targetIndexInGroup = 1,
+        )
+        assertEquals(listOf("s1", "s3", "s5", "s2", "s4"), result.map { it.id })
+        assertEquals("Ops", result.first { it.id == "s3" }.group)
+        assertEquals("Ops", result.first { it.id == "s5" }.group)
+        assertEquals("Dev", result.first { it.id == "s4" }.group)
+    }
+
+    @Test
+    fun `renameSnippetGroup renames group across snippets`() {
+        val snippets = listOf(
+            snippet("s1", "Ops"),
+            snippet("s2", "Ops"),
+            snippet("s3", "Dev"),
+        )
+        val result = renameSnippetGroup(snippets, oldName = "Ops", newName = "Operations")
+        assertEquals(listOf("Operations", "Operations", "Dev"), result.map { it.group })
+        assertEquals(listOf("s1", "s2", "s3"), result.map { it.id })
+    }
+
+    @Test
+    fun `renameSnippetGroup ungroups when newName is blank`() {
+        val snippets = listOf(
+            snippet("s1", "Ops"),
+            snippet("s2", "Dev"),
+        )
+        val result = renameSnippetGroup(snippets, oldName = "Ops", newName = "")
+        assertEquals(null, result.first { it.id == "s1" }.group)
+        assertEquals("Dev", result.first { it.id == "s2" }.group)
+    }
+
+    @Test
+    fun `moveSnippetGroup reorders whole folder blocks`() {
+        val snippets = listOf(
+            snippet("s1", "Alpha"),
+            snippet("s2", "Alpha"),
+            snippet("s3", "Beta"),
+            snippet("s4", "Gamma"),
+        )
+        val result = moveSnippetGroup(snippets, group = "Gamma", targetGroupIndex = 0)
+        assertEquals(listOf("s4", "s1", "s2", "s3"), result.map { it.id })
+
+        val result2 = moveSnippetGroup(snippets, group = "Alpha", targetGroupIndex = 2)
+        assertEquals(listOf("s3", "s4", "s1", "s2"), result2.map { it.id })
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/runbook/RunbookStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/runbook/RunbookStore.kt
@@ -14,4 +14,14 @@ interface RunbookStore {
 
     /** Removes the record by id; missing id is a no-op. */
     fun remove(id: String)
+
+    /**
+     * Atomically computes and applies an order/content transform across all runbooks.
+     */
+    fun reorder(transform: (List<Runbook>) -> List<Runbook>) {
+        val current = all()
+        val updated = transform(current)
+        current.forEach { remove(it.id) }
+        updated.forEach { put(it) }
+    }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/runbook/VaultRunbookStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/runbook/VaultRunbookStore.kt
@@ -4,34 +4,62 @@ import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.TrashStore
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecordCodec
+import app.skerry.shared.vault.WorkspaceLayoutStore
 
 /**
  * [RunbookStore] over an encrypted [Vault]: each runbook is a [RecordType.RUNBOOK] record whose
  * payload is the JSON serialization of [Runbook]. Like snippets, the commands can carry inline
  * credentials, so they get the same encryption and E2E sync.
  *
- * Runbooks have no defined order (set semantics), so no separate order record is needed; entries
- * come back in [Vault.records] order. Reading a locked vault returns an empty list; a corrupt
- * payload is silently skipped.
+ * Order is stored in [WorkspaceLayout] to preserve manual drag-and-drop ordering across sync and
+ * sessions. Reading a locked vault returns an empty list; a corrupt payload is silently skipped.
  */
 class VaultRunbookStore(
     private val vault: Vault,
     /** Trash to snapshot deletions into; opt-in — see [app.skerry.shared.host.VaultHostStore]. */
     trash: TrashStore? = null,
+    private val layout: WorkspaceLayoutStore = WorkspaceLayoutStore(vault),
 ) : RunbookStore {
 
     private val codec = VaultRecordCodec(vault, RecordType.RUNBOOK, Runbook.serializer(), trash) { it.label }
 
     override fun all(): List<Runbook> {
         if (!vault.isUnlocked) return emptyList()
-        return codec.list()
+        val runbooks = codec.list()
+        val order = layout.read().runbookOrder
+        if (order.isEmpty()) return runbooks
+        val rank = order.withIndex().associate { (i, id) -> id to i }
+        return runbooks.sortedBy { rank[it.id] ?: Int.MAX_VALUE }
     }
 
-    override fun put(runbook: Runbook) {
+    override fun put(runbook: Runbook) = vault.transaction {
         codec.put(runbook.id, runbook)
+        val current = layout.readOrNull() ?: return@transaction
+        if (runbook.id !in current.runbookOrder) {
+            layout.write(current.copy(runbookOrder = current.runbookOrder + runbook.id))
+        }
     }
 
-    override fun remove(id: String) {
+    override fun remove(id: String) = vault.transaction {
         codec.remove(id)
+        val current = layout.readOrNull() ?: return@transaction
+        if (id in current.runbookOrder) {
+            layout.write(current.copy(runbookOrder = current.runbookOrder - id))
+        }
+    }
+
+    override fun reorder(transform: (List<Runbook>) -> List<Runbook>) = vault.transaction {
+        val current = all()
+        val updated = transform(current)
+        require(updated.size == current.size && updated.map { it.id }.toSet() == current.map { it.id }.toSet()) {
+            "reorder must preserve the id set (had ${current.size}, got ${updated.size})"
+        }
+        val byId = current.associateBy { it.id }
+        for (runbook in updated) {
+            if (byId[runbook.id] != runbook) codec.put(runbook.id, runbook)
+        }
+        val existing = layout.readOrNull() ?: return@transaction
+        val order = updated.map { it.id }
+        if (order != existing.runbookOrder) layout.write(existing.copy(runbookOrder = order))
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetStore.kt
@@ -13,4 +13,14 @@ interface SnippetStore {
 
     /** Removes the record by id; missing id is a no-op. */
     fun remove(id: String)
+
+    /**
+     * Atomically computes and applies an order/content transform across all snippets.
+     */
+    fun reorder(transform: (List<Snippet>) -> List<Snippet>) {
+        val current = all()
+        val updated = transform(current)
+        current.forEach { remove(it.id) }
+        updated.forEach { put(it) }
+    }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/VaultSnippetStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/VaultSnippetStore.kt
@@ -4,34 +4,62 @@ import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.TrashStore
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecordCodec
+import app.skerry.shared.vault.WorkspaceLayoutStore
 
 /**
  * [SnippetStore] over an encrypted [Vault]: each snippet is a [RecordType.SNIPPET] record whose
  * payload is the JSON serialization of [Snippet]. Commands may contain inline credentials, so they
  * get the same encryption and E2E sync as other secrets.
  *
- * Snippets have no defined order (the interface has set semantics), so no separate order record
- * is needed; entries come back in [Vault.records] order. Reading a locked vault returns an empty
- * list; a corrupt payload is silently skipped.
+ * Order is stored in [WorkspaceLayout] to preserve manual drag-and-drop ordering across sync and
+ * sessions. Reading a locked vault returns an empty list; a corrupt payload is silently skipped.
  */
 class VaultSnippetStore(
     private val vault: Vault,
     /** Trash to snapshot deletions into; opt-in — see [app.skerry.shared.host.VaultHostStore]. */
     trash: TrashStore? = null,
+    private val layout: WorkspaceLayoutStore = WorkspaceLayoutStore(vault),
 ) : SnippetStore {
 
     private val codec = VaultRecordCodec(vault, RecordType.SNIPPET, Snippet.serializer(), trash) { it.label }
 
     override fun all(): List<Snippet> {
         if (!vault.isUnlocked) return emptyList()
-        return codec.list()
+        val snippets = codec.list()
+        val order = layout.read().snippetOrder
+        if (order.isEmpty()) return snippets
+        val rank = order.withIndex().associate { (i, id) -> id to i }
+        return snippets.sortedBy { rank[it.id] ?: Int.MAX_VALUE }
     }
 
-    override fun put(snippet: Snippet) {
+    override fun put(snippet: Snippet) = vault.transaction {
         codec.put(snippet.id, snippet)
+        val current = layout.readOrNull() ?: return@transaction
+        if (snippet.id !in current.snippetOrder) {
+            layout.write(current.copy(snippetOrder = current.snippetOrder + snippet.id))
+        }
     }
 
-    override fun remove(id: String) {
+    override fun remove(id: String) = vault.transaction {
         codec.remove(id)
+        val current = layout.readOrNull() ?: return@transaction
+        if (id in current.snippetOrder) {
+            layout.write(current.copy(snippetOrder = current.snippetOrder - id))
+        }
+    }
+
+    override fun reorder(transform: (List<Snippet>) -> List<Snippet>) = vault.transaction {
+        val current = all()
+        val updated = transform(current)
+        require(updated.size == current.size && updated.map { it.id }.toSet() == current.map { it.id }.toSet()) {
+            "reorder must preserve the id set (had ${current.size}, got ${updated.size})"
+        }
+        val byId = current.associateBy { it.id }
+        for (snippet in updated) {
+            if (byId[snippet.id] != snippet) codec.put(snippet.id, snippet)
+        }
+        val existing = layout.readOrNull() ?: return@transaction
+        val order = updated.map { it.id }
+        if (order != existing.snippetOrder) layout.write(existing.copy(snippetOrder = order))
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/WorkspaceLayout.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/WorkspaceLayout.kt
@@ -26,6 +26,10 @@ data class WorkspaceLayout(
      * list.
      */
     val remoteDesktopGroups: List<String> = emptyList(),
+    /** Global order of snippet ids in the library. */
+    val snippetOrder: List<String> = emptyList(),
+    /** Global order of runbook ids in the library. */
+    val runbookOrder: List<String> = emptyList(),
 )
 
 /**

--- a/shared/src/commonTest/kotlin/app/skerry/shared/runbook/VaultRunbookStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/runbook/VaultRunbookStoreTest.kt
@@ -66,4 +66,20 @@ class VaultRunbookStoreTest {
         assertEquals("Drain", stored.label)
         assertNull(stored.group)
     }
+
+    @Test
+    fun `reorder updates and persists order in layout`() {
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1"))
+        store.put(runbook("r2"))
+        store.put(runbook("r3"))
+
+        assertEquals(listOf("r1", "r2", "r3"), store.all().map { it.id })
+
+        store.reorder { listOf(it[2], it[0], it[1]) }
+
+        val freshStore = VaultRunbookStore(vault)
+        assertEquals(listOf("r3", "r1", "r2"), freshStore.all().map { it.id })
+    }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/snippet/VaultSnippetStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/snippet/VaultSnippetStoreTest.kt
@@ -58,4 +58,20 @@ class VaultSnippetStoreTest {
         assertEquals("Disk", stored.label)
         assertNull(stored.group)
     }
+
+    @Test
+    fun `reorder updates and persists order in layout`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1"))
+        store.put(snippet("s2"))
+        store.put(snippet("s3"))
+
+        assertEquals(listOf("s1", "s2", "s3"), store.all().map { it.id })
+
+        store.reorder { listOf(it[2], it[0], it[1]) }
+
+        val freshStore = VaultSnippetStore(vault)
+        assertEquals(listOf("s3", "s1", "s2"), freshStore.all().map { it.id })
+    }
 }


### PR DESCRIPTION
### Summary
This PR brings manual drag-and-drop folder reordering to Snippets and Runbooks (matching the existing Host sidebar capability) and improves the overall folder dragging UX across desktop and mobile platforms:

1. **First-appearance folder order**: Replaced the rigid alphabetical sorting in `foldersOf()` with natural first-appearance order, allowing user-defined drag-and-drop reordering across all foldered sections.
2. **Folder reordering for Snippets & Runbooks**: Added `moveSnippetGroup` and `moveRunbookGroup` with pure reordering algorithms and full unit test coverage.
3. **Compact drag UX**: When dragging any folder, all folder sections temporarily collapse into compact headers during the gesture, eliminating large vertical jumps and making reordering fast and predictable. Folders instantly restore their previous expansion states upon release.
4. **Touch & Click gesture conflict resolution**: Isolated fold click targets to the chevron/text elements, preventing row-level click handlers from intercepting mouse drags or touch long-presses.
5. **Drop indicator enhancement**: Improved `DropLine` visibility with a 3px glowing cyan pill and anchor dots for clear visual feedback on both high-DPI desktop screens and mobile displays.

Discovered and refined during normal daily use across desktop and Android devices.