### PR TITLE
Put the terminal's shrink-to-fit behind a switch

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -272,6 +272,8 @@ class MainActivity : FragmentActivity() {
                     onAllowServerClipboardWriteChange = { writeClipboardWrite(dir, it) },
                     initialReportTeamSessions = readReportTeamSessions(dir),
                     onReportTeamSessionsChange = { writeReportTeamSessions(dir, it) },
+                    initialTerminalAutoFit = readTerminalAutoFit(dir),
+                    onTerminalAutoFitChange = { writeTerminalAutoFit(dir, it) },
                     initialOpenFilePathsInSftp = readOpenFilePaths(dir),
                     onOpenFilePathsInSftpChange = { writeOpenFilePaths(dir, it) },
                     initialHighlightCommandLine = readHighlightInput(dir),
@@ -435,6 +437,17 @@ class MainActivity : FragmentActivity() {
     private fun writeReportTeamSessions(dir: File, enabled: Boolean) {
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "teams_report_sessions").writeText(enabled.toString()) }
+        }
+    }
+
+    /** Terminal shrink-to-fit: `terminal_autofit`, default off. */
+    private fun readTerminalAutoFit(dir: File): Boolean = runCatching {
+        File(dir, "terminal_autofit").readText().trim().toBoolean()
+    }.getOrDefault(false)
+
+    private fun writeTerminalAutoFit(dir: File, enabled: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "terminal_autofit").writeText(enabled.toString()) }
         }
     }
 

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -102,6 +102,8 @@
     <string name="settings_terminal_clipboard_write">Разрешить серверу писать в буфер обмена (OSC 52)</string>
     <string name="settings_hide_system_bars">Скрывать системные панели в сессии</string>
     <string name="settings_hide_system_bars_desc">Терминал и удалённый рабочий стол занимают весь экран. Панели возвращаются свайпом от края.</string>
+    <string name="settings_terminal_autofit">Уменьшать шрифт под ширину</string>
+    <string name="settings_terminal_autofit_desc">Широкий вывод уменьшает шрифт терминала, пока строки не перестанут переноситься. Чип −/+ над выводом правит масштаб.</string>
     <string name="settings_terminal_open_paths">Открытие файловых путей в SFTP</string>
     <string name="settings_terminal_open_paths_desc">Ctrl+клик по пути в выводе открывает его в файловой панели.</string>
     <string name="settings_terminal_open_paths_desc_mobile">Долгое нажатие на путь в выводе, затем «Открыть в Файлах».</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -102,6 +102,8 @@
     <string name="settings_terminal_clipboard_write">允许服务器写入剪贴板 (OSC 52)</string>
     <string name="settings_hide_system_bars">会话中隐藏系统栏</string>
     <string name="settings_hide_system_bars_desc">终端和远程桌面将占满整个屏幕。从屏幕边缘滑动即可让系统栏返回。</string>
+    <string name="settings_terminal_autofit">缩小字体以适应宽度</string>
+    <string name="settings_terminal_autofit_desc">输出过宽时缩小终端字体，直到不再换行。输出上方的 −/+ 小标可手动调整。</string>
     <string name="settings_terminal_open_paths">在 SFTP 中打开文件路径</string>
     <string name="settings_terminal_open_paths_desc">按住 Ctrl 点击输出中的路径，即可在文件面板中定位。</string>
     <string name="settings_terminal_open_paths_desc_mobile">长按输出中的路径，然后点按“在文件中打开”。</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -102,6 +102,8 @@
     <string name="settings_terminal_clipboard_write">Allow server clipboard writes (OSC 52)</string>
     <string name="settings_hide_system_bars">Hide system bars in a session</string>
     <string name="settings_hide_system_bars_desc">The terminal and the remote desktop take the whole display. The bars come back on a swipe from the edge.</string>
+    <string name="settings_terminal_autofit">Shrink the font to fit</string>
+    <string name="settings_terminal_autofit_desc">Wide output scales the terminal font down until it stops wrapping. The −/+ chip over the output adjusts it.</string>
     <string name="settings_terminal_open_paths">Open file paths in SFTP</string>
     <string name="settings_terminal_open_paths_desc">Ctrl+click a file path in the output to reveal it in the file panel.</string>
     <string name="settings_terminal_open_paths_desc_mobile">Long-press a file path in the output, then tap “Open in Files”.</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -172,6 +172,12 @@ class MobileDesignState(
     private val onHighlightCommandLineChange: (Boolean) -> Unit = {},
     initialHighlightOutput: Boolean = false,
     private val onHighlightOutputChange: (Boolean) -> Unit = {},
+    // Whether the terminal shrinks its font to fit wide output (More → Appearance → Terminal).
+    // Phone-only and off by default: the fit rewrites the font size the user picked, which is a
+    // rescue for wide output and an annoyance for everyone who sized the terminal on purpose.
+    // Persisted on Android; no-op default for previews/tests.
+    initialTerminalAutoFit: Boolean = false,
+    private val onTerminalAutoFitChange: (Boolean) -> Unit = {},
     // Production guard: also confirm Warn-level commands (Settings → Terminal). Off by default.
     initialConfirmProductionWarnings: Boolean = false,
     private val onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
@@ -423,6 +429,13 @@ class MobileDesignState(
     var highlightOutput: Boolean by mutableStateOf(initialHighlightOutput); private set
 
     /**
+     * Whether the terminal auto-shrinks its font until wide output stops wrapping (More →
+     * Appearance → Terminal). Phone-only — there is no desktop counterpart, the fit exists for a
+     * screen too narrow for the output. Off by default: it overrides the chosen font size.
+     */
+    var terminalAutoFit: Boolean by mutableStateOf(initialTerminalAutoFit); private set
+
+    /**
      * Whether the production guard also confirms Warn-level commands (More → Terminal). Off by
      * default — desktop parity, see [app.skerry.ui.app.DesktopDesignState.confirmProductionWarnings].
      */
@@ -491,6 +504,12 @@ class MobileDesignState(
     fun toggleHideSessionSystemBars() {
         hideSessionSystemBars = !hideSessionSystemBars
         onHideSessionSystemBarsChange(hideSessionSystemBars)
+    }
+
+    /** Toggle the terminal's shrink-to-fit and report outward (for persistence). */
+    fun toggleTerminalAutoFit() {
+        terminalAutoFit = !terminalAutoFit
+        onTerminalAutoFitChange(terminalAutoFit)
     }
 
     /** Toggle offering "Open in Files" for a selected file path and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppearanceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppearanceScreen.kt
@@ -50,6 +50,8 @@ import app.skerry.ui.generated.resources.appearance_custom_term_theme_desc
 import app.skerry.ui.generated.resources.appearance_section_terminal
 import app.skerry.ui.generated.resources.settings_hide_system_bars
 import app.skerry.ui.generated.resources.settings_hide_system_bars_desc
+import app.skerry.ui.generated.resources.settings_terminal_autofit
+import app.skerry.ui.generated.resources.settings_terminal_autofit_desc
 import app.skerry.ui.generated.resources.settings_terminal_open_paths
 import app.skerry.ui.generated.resources.settings_terminal_open_paths_desc_mobile
 import app.skerry.ui.generated.resources.settings_terminal_highlight_input
@@ -154,6 +156,16 @@ fun MobileAppearanceScreen(state: MobileDesignState) {
                     fieldWidth = 52.dp,
                 )
             }
+            // Shrink-to-fit, right below the size sliders it overrides. Phone-only (there is no
+            // desktop counterpart) and off by default: a font size chosen by hand should not be
+            // rewritten by the first wide line unless the user asked for it.
+            HLine()
+            MobileToggleRow(
+                title = stringResource(Res.string.settings_terminal_autofit),
+                desc = stringResource(Res.string.settings_terminal_autofit_desc),
+                on = state.terminalAutoFit,
+                onToggle = state::toggleTerminalAutoFit,
+            )
             // Scrollback depth and default cursor style for new sessions (behaviour, desktop parity).
             // Both apply to new sessions at connect and are pushed live into already-open ones.
             HLine()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -238,6 +238,21 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                             if (liveAi != null && liveAi.enabled && AiPolicyDecision.of(aiPolicy).aiEnabled) liveAi.terminalController(aiPolicy) else null
                         }
                     }
+                    // The fit's memory is per session and only meaningful while the feature is on:
+                    // cleared whenever the switch is off, so turning it back on gives a fresh fit
+                    // instead of a scale — and a `locked` — left over from before. Without this the
+                    // switch reads as freshly enabled while no wide line can ever shrink the font
+                    // again for that session.
+                    // Relies on Compose disposing TerminalScreen's convergence effect before this
+                    // one is launched: both write the same fit state, and the collector must be
+                    // gone before the clear, or the very snapshot that arrives during the flip
+                    // would step a machine that is supposed to be fresh. Compose dispatches
+                    // onForgotten before onRemembered on the same recompose context, and the
+                    // convergence effect is structurally inside `if (autoFitOn)` — so the two can
+                    // never run against each other. Named here because nothing enforces it.
+                    LaunchedEffect(st.terminal, state.terminalAutoFit) {
+                        if (!state.terminalAutoFit) st.terminal.autoFit.reset()
+                    }
                     Box(Modifier.weight(1f).fillMaxWidth()) {
                         TerminalScreen(
                             st.terminal,
@@ -246,11 +261,18 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                             imeTransform = imeTransform,
                             // Wide output on a phone turns into a wall of wrapped lines; the fit
                             // converges once per session and the controls below nudge it after.
-                            autoFitEnabled = true,
+                            // Opt-in (More → Appearance → Terminal): off, the terminal keeps the
+                            // font size from Appearance no matter how wide the output gets.
+                            autoFitEnabled = state.terminalAutoFit,
                         )
+                        // Composed whether or not the feature is on, and told which it is: the
+                        // controls carry the screen-reader announcer for the scale, and a live
+                        // region re-inserted on re-enable would arrive carrying its value instead
+                        // of changing into it — announcing nothing.
                         TerminalAutoFitControls(
                             fit = st.terminal.autoFit,
                             floor = autoFitFloor(LocalTerminalAppearance.current.fontSizeSp),
+                            enabled = state.terminalAutoFit,
                             modifier = Modifier.align(Alignment.BottomEnd).padding(end = 10.dp, bottom = 8.dp),
                         )
                     }
@@ -299,6 +321,10 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                     // session's command queue is closed, so a nudge could only rescale glyphs
                     // without reflowing the grid — "+" would clip the tails of the very wide
                     // lines being read.
+                    // Unconditionally on, unlike the live branch above: the Appearance switch
+                    // decides whether a fit *engages*, and turning it off later must not re-wrap a
+                    // screen frozen at a scale that already fits. A session that never engaged sits
+                    // at 1f here anyway, and the effect below leaves a dead session alone.
                     TerminalScreen(st.terminal, Modifier.weight(1f).fillMaxWidth(), autoFitEnabled = true)
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalAutoFit.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalAutoFit.kt
@@ -153,6 +153,18 @@ class TerminalAutoFitState {
         scale = 1f
     }
 
+    /**
+     * Back to what a fresh session has: the user's own size, nothing locked, nothing converged.
+     * Called when the Appearance switch turns the fit off — the machine's memory is only meaningful
+     * while the feature is on, and carrying [locked] across an off/on cycle would leave a switch
+     * that reads as freshly enabled driving a fit that can never engage again for that session.
+     */
+    fun reset() {
+        phase = Phase.Waiting
+        scale = 1f
+        locked = false
+    }
+
     private fun stepDown(value: Float, floor: Float): Float =
         (value * AUTOFIT_STEP).coerceAtLeast(floor.coerceAtMost(1f))
 }
@@ -186,7 +198,7 @@ fun gridNeedsShrink(screen: List<List<TermCell>>, rows: Int, cursorRow: Int): Bo
 
 /**
  * Manual −/+ nudge over the mobile terminal, with the current scale as a percentage. Nothing is
- * drawn until the fit first engages ([TerminalAutoFitState.active]) — a session that never printed
+ * drawn while the feature is off ([enabled]) or until the fit first engages ([TerminalAutoFitState.active]) — a session that never printed
  * a wide line keeps its screen clean. Buttons that can do nothing are hidden, not disabled: "−"
  * disappears at the floor and "+" at the user's own size, since a permanently dead button under
  * the thumb reads as broken. Long-pressing "+" restores the user's size in one gesture.
@@ -196,13 +208,24 @@ fun gridNeedsShrink(screen: List<List<TermCell>>, rows: Int, cursorRow: Int): Bo
  * in the light themes (the RemoteDesktopBar precedent).
  */
 @Composable
-fun TerminalAutoFitControls(fit: TerminalAutoFitState, floor: Float, modifier: Modifier = Modifier) {
+fun TerminalAutoFitControls(
+    fit: TerminalAutoFitState,
+    floor: Float,
+    /**
+     * The Appearance switch. Passed in rather than gating the call site, so the announcer below
+     * keeps its mount while the feature is off: a caller that skips this composable entirely
+     * re-inserts the live region on re-enable, which is the one thing it must never do.
+     */
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
     // The announcer is composed from screen mount, BEFORE the active gate: a live region that
     // appears together with its first value is an insertion, not a change, and Android announces
     // only changes — the auto-engage moment (the one change the user did not cause themselves)
     // would stay silent. StatusAnnouncer also carries the size workaround a 0dp node needs.
-    StatusAnnouncer(if (fit.active) "${(fit.scale * 100).roundToInt()}%" else "")
-    if (!fit.active) return
+    val on = enabled && fit.active
+    StatusAnnouncer(if (on) "${(fit.scale * 100).roundToInt()}%" else "")
+    if (!on) return
     val chip = Skerry.colors.surface2.copy(alpha = 0.95f)
     Row(
         modifier,

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
@@ -80,6 +80,18 @@ class MobileDesignStateTest {
     }
 
     @Test
+    fun toggleTerminalAutoFit_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = MobileDesignState(onTerminalAutoFitChange = { seen += it })
+        assertEquals(false, s.terminalAutoFit) // off by default: the fit rewrites the font size the user chose
+        s.toggleTerminalAutoFit()
+        assertEquals(true, s.terminalAutoFit)
+        s.toggleTerminalAutoFit()
+        assertEquals(false, s.terminalAutoFit)
+        assertEquals(listOf(true, false), seen)
+    }
+
+    @Test
     fun toggleAllowServerClipboardWrite_flips_and_reports() {
         val seen = mutableListOf<Boolean>()
         val s = MobileDesignState(onAllowServerClipboardWriteChange = { seen += it })

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitTest.kt
@@ -166,6 +166,28 @@ class TerminalAutoFitTest {
     }
 
     @Test
+    fun `reset returns a converged and locked fit to a fresh one`() {
+        val floor = autoFitFloor(13)
+        val fit = TerminalAutoFitState()
+        fit.onScreenSettled(wrapped = true, floor = floor)
+        fit.onScreenSettled(wrapped = false, floor = floor)
+        fit.onScreenSettled(wrapped = false, floor = floor)
+        fit.nudgeDown(floor)
+        assertTrue(fit.converged && fit.locked && fit.scale < 1f)
+
+        fit.reset()
+
+        assertEquals(1f, fit.scale)
+        assertFalse(fit.locked)
+        assertFalse(fit.converged)
+        assertFalse(fit.active)
+        // And it fits again from scratch: a reset that only cleared the flags would leave the
+        // machine in a phase where the next wide line takes it straight to convergence.
+        fit.onScreenSettled(wrapped = true, floor = floor)
+        assertEquals(0.9f, fit.scale, absoluteTolerance = 1e-4f)
+    }
+
+    @Test
     fun `the line being typed under the cursor does not shrink the font`() {
         // The user's own command line soft-wraps while being typed: rows 2-3 are one logical line
         // with the cursor on its tail. Shrinking mid-typing would yank the font under the finger.

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileAutoFitGateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileAutoFitGateTest.kt
@@ -1,0 +1,97 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.onNodeWithContentDescription
+import app.skerry.ui.app.MobileRoute
+import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.desktop.runMobileShell
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.term_autofit_grow
+import app.skerry.ui.terminal.autoFitFloor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+/**
+ * The Appearance switch governs the whole shrink-to-fit feature on the phone: whether the scale
+ * reaches the glyphs, whether the −/+ chip is on screen, and what is left behind when it goes off.
+ *
+ * Everything here is invisible from the state machine's own unit tests, because the fit's state
+ * lives on the session ([app.skerry.ui.terminal.TerminalScreenState]) and outlives the switch:
+ * a gate that only stopped the *stepping* would leave a chip over a terminal that no longer
+ * scales, and a switch that left `locked` behind would read as freshly enabled while no wide line
+ * could ever shrink the font again. The engaged state is forced by hand — the honest convergence
+ * path needs a live reflow and is covered by TerminalAutoFitLiveTest.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobileAutoFitGateTest {
+
+    /** The scale announcer for screen readers (see StatusAnnouncer's insertion-vs-change contract). */
+    private val polite = SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, LiveRegionMode.Polite)
+
+    @Test
+    fun `the switch governs the scale, the chip and what the fit remembers`() = runMobileShell(withSessions = true) { shell ->
+        shell.state.push(MobileRoute.Terminal)
+        waitForIdle()
+        val ui = shell.sessions?.active?.focusedPane?.controller?.uiState
+        val connected = assertNotNull(ui as? ConnectionUiState.Connected, "the seeded session is not connected")
+        // The grid the terminal settles on at the user's own font size — read after the first
+        // layout resize has landed, not before it: the default 80x24 is not what is on screen.
+        settle()
+        val unscaled = connected.terminal.cols
+        onNodeWithContentDescription(string(Res.string.term_autofit_grow)).assertDoesNotExist()
+
+        shell.state.toggleTerminalAutoFit()
+        // Applied as a snapshot: a bare write from the test thread reaches the state but not the
+        // composition until something else happens to send apply notifications.
+        Snapshot.withMutableSnapshot { connected.terminal.autoFit.nudgeDown(autoFitFloor(13)) }
+        // The scale reaches the glyphs or it does not: a smaller font measures a wider grid, which
+        // is the one effect of the switch observable without reading pixels. The wait covers the
+        // resize debounce between the font change and the regrown grid.
+        waitUntil("the shrunken font widens the grid", timeoutMillis = 10_000) {
+            connected.terminal.cols > unscaled
+        }
+        onNodeWithContentDescription(string(Res.string.term_autofit_grow)).assertExists()
+        val liveRegions = onAllNodes(polite).fetchSemanticsNodes().size
+
+        shell.state.toggleTerminalAutoFit()
+        settle()
+
+        onNodeWithContentDescription(string(Res.string.term_autofit_grow)).assertDoesNotExist()
+        assertEquals(unscaled, connected.terminal.cols, "the terminal kept a scale the switch had turned off")
+        // The announcer keeps its mount and goes silent instead of disappearing: a live region
+        // re-inserted on the next enable would arrive carrying its value rather than changing into
+        // it, and Android announces only changes. Counted rather than matched by name — the screen
+        // carries other polite regions, and what this pins is that none of them went away and none
+        // is still reading out a scale.
+        assertEquals(liveRegions, onAllNodes(polite).fetchSemanticsNodes().size, "a live region was unmounted with the chip")
+        val announced = onAllNodes(polite).fetchSemanticsNodes()
+            .flatMap { it.config.getOrNull(SemanticsProperties.ContentDescription).orEmpty() }
+            .filter { it.isNotBlank() }
+        assertEquals(emptyList(), announced, "a live region still announces a scale after the switch went off")
+        // And the fit forgets, so the next enable is a fresh one rather than a locked no-op.
+        assertEquals(1f, connected.terminal.autoFit.scale, "the fit kept its scale across the switch")
+        assertFalse(connected.terminal.autoFit.locked, "a re-enable would start locked out")
+    }
+
+    /**
+     * Renders past the terminal's resize debounce (a real 150ms, off the test clock) so "nothing
+     * changed" is asserted over an observation window rather than a single frame.
+     */
+    private fun ComposeUiTest.settle() {
+        repeat(40) {
+            Thread.sleep(16)
+            // Driven by hand: `waitForIdle` renders nothing when the tree already reads as idle,
+            // and a composition left behind by a write from the test thread is exactly that.
+            mainClock.advanceTimeByFrame()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileSettingsTogglesTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileSettingsTogglesTest.kt
@@ -13,6 +13,7 @@ import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.appearance_custom_term_theme
 import app.skerry.ui.generated.resources.settings_security_report_team_sessions
+import app.skerry.ui.generated.resources.settings_terminal_autofit
 import app.skerry.ui.generated.resources.settings_terminal_prod_warnings
 import org.jetbrains.compose.resources.StringResource
 import kotlin.test.Test
@@ -56,6 +57,19 @@ class MobileSettingsTogglesTest {
         waitForIdle()
 
         assertTrue(shell.state.customTerminalTheme)
+    }
+
+    @Test
+    fun `the auto-fit switch reaches the setting`() = runMobileShell { shell ->
+        shell.state.push(MobileRoute.Appearance)
+        waitForIdle()
+        assertFalse(shell.state.terminalAutoFit, "auto-fit is opt-in")
+
+        onSwitch(Res.string.settings_terminal_autofit).assertIsOff().performClick()
+        waitForIdle()
+
+        assertTrue(shell.state.terminalAutoFit)
+        onSwitch(Res.string.settings_terminal_autofit).assertIsOn()
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitControlsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitControlsTest.kt
@@ -35,7 +35,7 @@ class TerminalAutoFitControlsTest {
     @Test
     fun `nothing is drawn until the fit engages`() {
         val fit = TerminalAutoFitState()
-        runForm({ TerminalAutoFitControls(fit, floor) }) {
+        runForm({ TerminalAutoFitControls(fit, floor, enabled = true) }) {
             onNodeWithText("100%").assertDoesNotExist()
             onNodeWithContentDescription(string(Res.string.term_autofit_grow)).assertDoesNotExist()
             onNodeWithContentDescription(string(Res.string.term_autofit_shrink)).assertDoesNotExist()
@@ -46,10 +46,24 @@ class TerminalAutoFitControlsTest {
     }
 
     @Test
+    fun `the switch off draws nothing and keeps the announcer silent`() {
+        val fit = TerminalAutoFitState()
+        fit.onScreenSettled(wrapped = true, floor = floor)
+        runForm({ TerminalAutoFitControls(fit, floor, enabled = false) }) {
+            onNodeWithText("90%").assertDoesNotExist()
+            onNodeWithContentDescription(string(Res.string.term_autofit_grow)).assertDoesNotExist()
+            onNodeWithContentDescription(string(Res.string.term_autofit_shrink)).assertDoesNotExist()
+            // Silent, not absent: the live region has to be here already so that turning the
+            // feature back on is a change on an existing node rather than an insertion.
+            onNode(polite).assertContentDescriptionEquals("")
+        }
+    }
+
+    @Test
     fun `the engaged scale reaches the screen-reader announcer`() {
         val fit = TerminalAutoFitState()
         fit.onScreenSettled(wrapped = true, floor = floor)
-        runForm({ TerminalAutoFitControls(fit, floor) }) {
+        runForm({ TerminalAutoFitControls(fit, floor, enabled = true) }) {
             onNode(polite).assertContentDescriptionEquals("90%")
         }
     }
@@ -58,7 +72,7 @@ class TerminalAutoFitControlsTest {
     fun `a tap on plus steps the scale up and takes over from the machine`() {
         val fit = TerminalAutoFitState()
         fit.onScreenSettled(wrapped = true, floor = floor)
-        runForm({ TerminalAutoFitControls(fit, floor) }) {
+        runForm({ TerminalAutoFitControls(fit, floor, enabled = true) }) {
             onNodeWithText("90%").assertExists()
             onNodeWithContentDescription(string(Res.string.term_autofit_grow)).performClick()
             waitForIdle()
@@ -74,7 +88,7 @@ class TerminalAutoFitControlsTest {
     fun `a long press on plus restores the user's size in one gesture`() {
         val fit = TerminalAutoFitState()
         repeat(4) { fit.onScreenSettled(wrapped = true, floor = floor) }
-        runForm({ TerminalAutoFitControls(fit, floor) }) {
+        runForm({ TerminalAutoFitControls(fit, floor, enabled = true) }) {
             onNodeWithContentDescription(string(Res.string.term_autofit_grow))
                 .performTouchInput { longClick() }
             waitForIdle()
@@ -87,7 +101,7 @@ class TerminalAutoFitControlsTest {
     fun `a tap on minus steps the scale down and the button hides at the floor`() {
         val fit = TerminalAutoFitState()
         fit.onScreenSettled(wrapped = true, floor = floor)
-        runForm({ TerminalAutoFitControls(fit, floor) }) {
+        runForm({ TerminalAutoFitControls(fit, floor, enabled = true) }) {
             onNodeWithContentDescription(string(Res.string.term_autofit_shrink)).performClick()
             waitForIdle()
             assertEquals(0.9f * 0.9f, fit.scale, absoluteTolerance = 1e-4f)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitLiveTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitLiveTest.kt
@@ -68,14 +68,14 @@ class TerminalAutoFitLiveTest {
     private var frame = 0L
 
     @OptIn(ExperimentalComposeUiApi::class)
-    private fun autoFitScene(terminal: TerminalScreenState): ImageComposeScene =
+    private fun autoFitScene(terminal: TerminalScreenState, enabled: Boolean = true): ImageComposeScene =
         ImageComposeScene(width = 300, height = 400, density = Density(1f)) {
             SkerryTheme {
                 CompositionLocalProvider(
                     LocalFonts provides DesignFonts(rememberUiFont(), rememberMono(), rememberMaterialSymbols()),
                 ) {
                     Box(Modifier.fillMaxSize().background(Skerry.colors.terminalBg)) {
-                        TerminalScreen(terminal, Modifier.fillMaxSize(), autoFitEnabled = true)
+                        TerminalScreen(terminal, Modifier.fillMaxSize(), autoFitEnabled = enabled)
                     }
                 }
             }
@@ -135,6 +135,33 @@ class TerminalAutoFitLiveTest {
             waitForFrames(scene, framesAfterSettled = 30) { false }
             assertEquals(converged, terminal.autoFit.scale, "a remount reset the converged scale")
             assertTrue(terminal.autoFit.converged, "a remount re-armed convergence")
+        } finally {
+            scene.close()
+            scope.cancel()
+        }
+    }
+
+    /**
+     * The Appearance switch off (its default): the same wide output that converges the fit above
+     * must leave the font at the size the user chose, and leave the terminal without the nudge
+     * chrome. The setting is read on the phone only ([app.skerry.ui.mobile.MobileTerminalView]);
+     * what this pins is the screen's own contract behind it — a fit that keeps stepping with the
+     * switch off would rewrite a deliberately chosen font size on every wide line.
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Test
+    fun `with auto-fit off wide output leaves the font alone`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val session = ScriptedSession()
+        val terminal = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
+        val scene = autoFitScene(terminal, enabled = false)
+        try {
+            waitForFrames(scene) { terminal.cols in 20..50 } // first layout resize has landed
+            session.print("ok\r\n" + "x".repeat(50) + "\r\n$ ")
+            waitForFrames(scene, framesAfterSettled = 60) { false }
+            assertEquals(1f, terminal.autoFit.scale, "the fit stepped with the switch off")
+            assertFalse(terminal.autoFit.converged, "the fit ran with the switch off")
+            assertFalse(terminal.autoFit.active, "the nudge controls surfaced with the switch off")
         } finally {
             scene.close()
             scope.cancel()


### PR DESCRIPTION
The terminal's shrink-to-fit on the phone used to rewrite the font size the user picked the moment
a wide line arrived, with no way to decline. It is now a setting: **More → Appearance → Terminal →
"Shrink the font to fit"**, off by default and persisted on Android.

## Off (the default)

The terminal keeps the size chosen in Appearance no matter how wide the output gets, the
convergence loop never starts, and the −/+ chip stays off the screen. The fit's per-session memory
is cleared while the switch is off, so turning it back on begins a fresh fit rather than restoring
a scale — and a lock — from before.

## What the switch must not break

- **The screen reader's live region.** The nudge controls carry the announcer for the current
  scale. They are composed whether or not the feature is on and told which it is, because a live
  region re-inserted on re-enable would arrive carrying its value instead of changing into it, and
  Android announces only changes.
- **A frozen screen.** A disconnected session keeps auto-fit unconditionally. The switch decides
  whether a fit *engages*; turning it off must not re-wrap output frozen at a scale that already
  fits, on a session that can no longer reflow.

## Tests

- `MobileDesignStateTest` — default off, the toggle flips and reports outward.
- `MobileSettingsTogglesTest` — the Appearance switch reaches the setting.
- `MobileAutoFitGateTest` (new) — through the real mobile screen: the chip, the grid width, the
  live regions and what the fit remembers all follow the switch.
- `TerminalAutoFitTest` — `reset()` returns a converged and locked fit to a fresh one, verified by
  stepping the machine again afterwards.
- `TerminalAutoFitControlsTest` — the switch off draws nothing and keeps the announcer silent.
- `TerminalAutoFitLiveTest` — with auto-fit off, real wide output leaves the font alone.
