### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,5 +20,5 @@ android.useAndroidX=true
 # seeded at 116 because the APKs published up to 0.4.0 carried the CI run number instead of this
 # value, and the last one shipped as 115. The `version-bump` check blocks a versionName bump that
 # leaves the code behind.
-skerry.versionName=0.4.2
-skerry.versionCode=117
+skerry.versionName=0.4.3
+skerry.versionCode=118

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.4.2"
+version = "0.4.3"
 
 // Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
 // to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.4.2"
+version = "0.4.3"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Client and server move to 0.4.3 (`skerry.versionCode` 118).

Since 0.4.2 the change is client-side only:

- The mobile key panel is two fixed rows of nine keys with an `fn` layer for F1–F12 and the panel tools. Panel keys go through the same encoder as a hardware keyboard.
- Shrink-to-fit is now More → Appearance → Terminal → "Shrink the font to fit", off by default.
- Typing in the terminal on the soft keyboard no longer duplicates characters, and armed Ctrl with Backspace or Enter passes through instead of sending 0x1F.

`server/` and `sync-wire/` have no diff against 0.4.2; their version moves to stay in step.