### PR TITLE
feat(store): add order persistence for snippets and runbooks

### DIFF
--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookManagerTest.kt
@@ -16,6 +16,11 @@ class RunbookManagerTest {
         override fun all(): List<Runbook> = items.values.toList()
         override fun put(runbook: Runbook) { items[runbook.id] = runbook }
         override fun remove(id: String) { items.remove(id) }
+        override fun reorder(transform: (List<Runbook>) -> List<Runbook>) {
+            val updated = transform(all())
+            items.clear()
+            updated.forEach { items[it.id] = it }
+        }
     }
 
     private fun manager(store: RunbookStore = MemoryStore()): RunbookManager {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
@@ -547,4 +547,9 @@ private class FakeSnippetStore : SnippetStore {
     override fun remove(id: String) {
         entries.removeAll { it.id == id }
     }
+    override fun reorder(transform: (List<Snippet>) -> List<Snippet>) {
+        val updated = transform(entries.toList())
+        entries.clear()
+        entries.addAll(updated)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetStarterPackTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetStarterPackTest.kt
@@ -66,4 +66,9 @@ private class FakeStore : SnippetStore {
     override fun remove(id: String) {
         entries.removeAll { it.id == id }
     }
+    override fun reorder(transform: (List<Snippet>) -> List<Snippet>) {
+        val updated = transform(entries.toList())
+        entries.clear()
+        entries.addAll(updated)
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
@@ -137,6 +137,11 @@ internal fun seededSnippets(): SnippetManager {
             if (i >= 0) entries[i] = snippet else entries += snippet
         }
         override fun remove(id: String) { entries.removeAll { it.id == id } }
+        override fun reorder(transform: (List<Snippet>) -> List<Snippet>) {
+            val updated = transform(entries.toList())
+            entries.clear()
+            entries.addAll(updated)
+        }
     }
     var seq = 0
     return SnippetManager(store) { "snip-${seq++}" }
@@ -152,6 +157,11 @@ internal fun seededRunbooks(): RunbookManager {
             if (i >= 0) entries[i] = runbook else entries += runbook
         }
         override fun remove(id: String) { entries.removeAll { it.id == id } }
+        override fun reorder(transform: (List<Runbook>) -> List<Runbook>) {
+            val updated = transform(entries.toList())
+            entries.clear()
+            entries.addAll(updated)
+        }
     }
     var seq = 0
     return RunbookManager(store) { "run-${seq++}" }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/SnippetPaletteModalPresenceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/SnippetPaletteModalPresenceTest.kt
@@ -51,7 +51,7 @@ class SnippetPaletteModalPresenceTest {
             CompositionLocalProvider(
                 LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
             ) {
-                SnippetPalette(manager, onPick = {})
+                SnippetPalette(manager) {}
             }
         }
     }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/SnippetPaletteModalPresenceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/SnippetPaletteModalPresenceTest.kt
@@ -38,6 +38,11 @@ class SnippetPaletteModalPresenceTest {
         override fun remove(id: String) {
             entries.removeAll { it.id == id }
         }
+        override fun reorder(transform: (List<Snippet>) -> List<Snippet>) {
+            val updated = transform(entries.toList())
+            entries.clear()
+            entries.addAll(updated)
+        }
     }
 
     @Composable
@@ -46,7 +51,7 @@ class SnippetPaletteModalPresenceTest {
             CompositionLocalProvider(
                 LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
             ) {
-                SnippetPalette(manager) {}
+                SnippetPalette(manager, onPick = {})
             }
         }
     }

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -28,6 +28,8 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Task | Abstraction |
 |---|---|
 | Vault-backed JSON store (list of records) | `vault/VaultRecordCodec` |
+| Sorting records by a stored id list, and validating a reorder transform | `vault/RecordOrder`: `sortedByOrder`, `requireSameIds` — an id the order doesn't mention ranks last |
+| Manual order of a list that has to survive LWW sync | a singleton record of its own: `vault/WorkspaceLayout` (host tree), `vault/LibraryOrder` + `LibraryOrderStore` (snippets, runbooks) — `Vault.records()` order can't carry it |
 | Atomic file write with 0600 permissions | `vault/atomicWriteUtf8` (vault / log / bio) |
 | Constant-time secret comparison | `vault/constantTimeEquals` |
 | Port-forward state | `ssh/ForwardState` |

--- a/server/src/main/kotlin/app/skerry/server/routes/VaultRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/VaultRoutes.kt
@@ -26,6 +26,7 @@ import io.ktor.server.routing.put
 private val ALLOWED_TYPES = setOf(
     "HOST", "GROUP", "IDENTITY", "CREDENTIAL", "KNOWN_HOST", "SNIPPET", "TUNNEL", "SETTINGS",
     "TEAM", "TEAM_IDENTITY", "TEAM_PEER", "TRASH", "RUNBOOK", "RUNBOOK_RUN", "TRUSTED_CA",
+    "LIBRARY_ORDER",
 )
 
 /** Ciphertext storage: dataKey wrapping, delta reads, and batch push with LWW. */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/host/VaultHostStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/host/VaultHostStore.kt
@@ -5,6 +5,8 @@ import app.skerry.shared.vault.TrashStore
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecordCodec
 import app.skerry.shared.vault.WorkspaceLayoutStore
+import app.skerry.shared.vault.requireSameIds
+import app.skerry.shared.vault.sortedByOrder
 
 /**
  * [HostStore] over the encrypted [Vault]: each profile is a [RecordType.HOST] record whose payload
@@ -34,12 +36,7 @@ class VaultHostStore(
 
     override fun all(): List<Host> {
         if (!vault.isUnlocked) return emptyList()
-        val hosts = codec.list()
-        val order = layout.read().hostOrder
-        val rank = order.withIndex().associate { (i, id) -> id to i }
-        // Stable sort: hosts outside the order (new/synced) keep records()' relative order and are
-        // appended at the end.
-        return hosts.sortedBy { rank[it.id] ?: Int.MAX_VALUE }
+        return codec.list().sortedByOrder(layout.read().hostOrder) { it.id }
     }
 
     override fun put(host: Host) = vault.transaction {
@@ -71,11 +68,7 @@ class VaultHostStore(
         // with a stale order.
         val current = all()
         val updated = transform(current)
-        // Size + id set: a set-equality check alone would miss a duplicate (e.g. [A,B,C,A]), which
-        // would corrupt hostOrder and tree order (associate keeps the last index for a duplicate id).
-        require(updated.size == current.size && updated.map { it.id }.toSet() == current.map { it.id }.toSet()) {
-            "reorder must preserve the id set (had ${current.size}, got ${updated.size})"
-        }
+        requireSameIds(current, updated) { it.id }
         // Only rewrite profiles whose content actually changed (e.g. group via moveHostToGroup/
         // renameGroup) — a pure reorder shouldn't bump every record's version (extra sync traffic).
         val byId = current.associateBy { it.id }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/runbook/RunbookStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/runbook/RunbookStore.kt
@@ -14,4 +14,10 @@ interface RunbookStore {
 
     /** Removes the record by id; missing id is a no-op. */
     fun remove(id: String)
+
+    /**
+     * Atomically computes and applies an order/content transform across all runbooks.
+     * Implementations must ensure atomicity (e.g., via transaction) and preserve the id set.
+     */
+    fun reorder(transform: (List<Runbook>) -> List<Runbook>)
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/runbook/RunbookStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/runbook/RunbookStore.kt
@@ -6,7 +6,7 @@ package app.skerry.shared.runbook
  * must be thread-safe.
  */
 interface RunbookStore {
-    /** All runbooks in insertion/update order. */
+    /** All runbooks in library order: what [reorder] last set, then anything it doesn't cover. */
     fun all(): List<Runbook>
 
     /** Creates a new record or replaces the existing one with the same [Runbook.id] (upsert). */
@@ -16,8 +16,16 @@ interface RunbookStore {
     fun remove(id: String)
 
     /**
-     * Atomically computes and applies an order/content transform across all runbooks.
-     * Implementations must ensure atomicity (e.g., via transaction) and preserve the id set.
+     * Atomic reorder: [transform] receives the library in its current order and returns the new one
+     * (with updated [Runbook.group] when moving between folders). Read, compute and write happen
+     * under one lock, so an order computed from a stale snapshot can't clobber a concurrent write
+     * (a merge from background sync). The id set must not change: implementations reject a result
+     * that lost, gained or duplicated an entry, and the error must not carry the [Runbook] values
+     * themselves — they hold commands.
+     *
+     * Content changes in the result are saved either way, but the new order itself is dropped when
+     * the store cannot read where it keeps it — a caller that shows the order back to the user has
+     * to expect it to come back as it was on the next read.
      */
     fun reorder(transform: (List<Runbook>) -> List<Runbook>)
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/runbook/VaultRunbookStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/runbook/VaultRunbookStore.kt
@@ -4,34 +4,66 @@ import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.TrashStore
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecordCodec
+import app.skerry.shared.vault.WorkspaceLayoutStore
 
 /**
  * [RunbookStore] over an encrypted [Vault]: each runbook is a [RecordType.RUNBOOK] record whose
  * payload is the JSON serialization of [Runbook]. Like snippets, the commands can carry inline
  * credentials, so they get the same encryption and E2E sync.
  *
- * Runbooks have no defined order (set semantics), so no separate order record is needed; entries
- * come back in [Vault.records] order. Reading a locked vault returns an empty list; a corrupt
- * payload is silently skipped.
+ * Order is stored in [WorkspaceLayout] to preserve manual drag-and-drop ordering across sync and
+ * sessions. Reading a locked vault returns an empty list; a corrupt payload is silently skipped.
  */
 class VaultRunbookStore(
     private val vault: Vault,
     /** Trash to snapshot deletions into; opt-in — see [app.skerry.shared.host.VaultHostStore]. */
     trash: TrashStore? = null,
+    private val layout: WorkspaceLayoutStore = WorkspaceLayoutStore(vault),
 ) : RunbookStore {
 
     private val codec = VaultRecordCodec(vault, RecordType.RUNBOOK, Runbook.serializer(), trash) { it.label }
 
     override fun all(): List<Runbook> {
         if (!vault.isUnlocked) return emptyList()
-        return codec.list()
+        val runbooks = codec.list()
+        val order = layout.read().runbookOrder
+        if (order.isEmpty()) return runbooks
+        val rank = order.withIndex().associate { (i, id) -> id to i }
+        return runbooks.sortedBy { rank[it.id] ?: Int.MAX_VALUE }
     }
 
-    override fun put(runbook: Runbook) {
+    override fun put(runbook: Runbook) = vault.transaction {
         codec.put(runbook.id, runbook)
+        val current = layout.readOrNull() ?: return@transaction
+        if (current.runbookOrder.isEmpty()) {
+            // Migration: seed with all existing runbooks in codec order, then append the new one
+            val existingIds = codec.list().map { it.id }
+            layout.write(current.copy(runbookOrder = existingIds + runbook.id))
+        } else if (runbook.id !in current.runbookOrder) {
+            layout.write(current.copy(runbookOrder = current.runbookOrder + runbook.id))
+        }
     }
 
-    override fun remove(id: String) {
+    override fun remove(id: String) = vault.transaction {
         codec.remove(id)
+        val current = layout.readOrNull() ?: return@transaction
+        if (id in current.runbookOrder) {
+            layout.write(current.copy(runbookOrder = current.runbookOrder - id))
+        }
+    }
+
+    override fun reorder(transform: (List<Runbook>) -> List<Runbook>) = vault.transaction {
+        val current = all()
+        val updated = transform(current)
+        require(updated.size == current.size && updated.map { it.id }.toSet() == current.map { it.id }.toSet()) {
+            "reorder must preserve the id set (had ${current.size}, got ${updated.size})"
+        }
+        val byId = current.associateBy { it.id }
+        for (runbook in updated) {
+            if (byId[runbook.id] != runbook) codec.put(runbook.id, runbook)
+        }
+        val existing = layout.readOrNull() ?: return@transaction
+        val order = updated.map { it.id }
+        if (order != existing.runbookOrder) layout.write(existing.copy(runbookOrder = order))
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/runbook/VaultRunbookStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/runbook/VaultRunbookStore.kt
@@ -1,69 +1,60 @@
 package app.skerry.shared.runbook
 
+import app.skerry.shared.vault.LibraryOrderStore
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.TrashStore
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecordCodec
-import app.skerry.shared.vault.WorkspaceLayoutStore
+import app.skerry.shared.vault.requireSameIds
+import app.skerry.shared.vault.sortedByOrder
 
 /**
  * [RunbookStore] over an encrypted [Vault]: each runbook is a [RecordType.RUNBOOK] record whose
  * payload is the JSON serialization of [Runbook]. Like snippets, the commands can carry inline
  * credentials, so they get the same encryption and E2E sync.
  *
- * Order is stored in [WorkspaceLayout] to preserve manual drag-and-drop ordering across sync and
- * sessions. Reading a locked vault returns an empty list; a corrupt payload is silently skipped.
+ * Library order is stored apart, in [app.skerry.shared.vault.LibraryOrder], for the reasons spelled
+ * out in [app.skerry.shared.snippet.VaultSnippetStore]. Reading a locked vault returns an empty
+ * list; a corrupt payload is silently skipped.
  */
 class VaultRunbookStore(
     private val vault: Vault,
     /** Trash to snapshot deletions into; opt-in — see [app.skerry.shared.host.VaultHostStore]. */
     trash: TrashStore? = null,
-    private val layout: WorkspaceLayoutStore = WorkspaceLayoutStore(vault),
+    private val order: LibraryOrderStore = LibraryOrderStore(vault),
 ) : RunbookStore {
 
     private val codec = VaultRecordCodec(vault, RecordType.RUNBOOK, Runbook.serializer(), trash) { it.label }
 
     override fun all(): List<Runbook> {
         if (!vault.isUnlocked) return emptyList()
-        val runbooks = codec.list()
-        val order = layout.read().runbookOrder
-        if (order.isEmpty()) return runbooks
-        val rank = order.withIndex().associate { (i, id) -> id to i }
-        return runbooks.sortedBy { rank[it.id] ?: Int.MAX_VALUE }
+        return codec.list().sortedByOrder(order.read().runbooks) { it.id }
     }
 
-    override fun put(runbook: Runbook) = vault.transaction {
+    /** Leaves the order record alone — see [app.skerry.shared.snippet.VaultSnippetStore.put]. */
+    override fun put(runbook: Runbook) {
         codec.put(runbook.id, runbook)
-        val current = layout.readOrNull() ?: return@transaction
-        if (current.runbookOrder.isEmpty()) {
-            // Migration: seed with all existing runbooks in codec order, then append the new one
-            val existingIds = codec.list().map { it.id }
-            layout.write(current.copy(runbookOrder = existingIds + runbook.id))
-        } else if (runbook.id !in current.runbookOrder) {
-            layout.write(current.copy(runbookOrder = current.runbookOrder + runbook.id))
-        }
     }
 
     override fun remove(id: String) = vault.transaction {
+        // Removal and the order update under one vault lock; readOrNull so an unreadable record
+        // isn't replaced (it also carries the snippet order). See [VaultSnippetStore.remove].
         codec.remove(id)
-        val current = layout.readOrNull() ?: return@transaction
-        if (id in current.runbookOrder) {
-            layout.write(current.copy(runbookOrder = current.runbookOrder - id))
-        }
+        val current = order.readOrNull() ?: return@transaction
+        if (id in current.runbooks) order.write(current.copy(runbooks = current.runbooks - id))
     }
 
     override fun reorder(transform: (List<Runbook>) -> List<Runbook>) = vault.transaction {
+        // Read-compute-write under one vault lock — see [VaultSnippetStore.reorder] for each step.
         val current = all()
         val updated = transform(current)
-        require(updated.size == current.size && updated.map { it.id }.toSet() == current.map { it.id }.toSet()) {
-            "reorder must preserve the id set (had ${current.size}, got ${updated.size})"
-        }
+        requireSameIds(current, updated) { it.id }
         val byId = current.associateBy { it.id }
         for (runbook in updated) {
             if (byId[runbook.id] != runbook) codec.put(runbook.id, runbook)
         }
-        val existing = layout.readOrNull() ?: return@transaction
-        val order = updated.map { it.id }
-        if (order != existing.runbookOrder) layout.write(existing.copy(runbookOrder = order))
+        val existing = order.readOrNull() ?: return@transaction
+        val ids = updated.map { it.id }
+        if (ids != existing.runbooks) order.write(existing.copy(runbooks = ids))
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetStore.kt
@@ -13,4 +13,10 @@ interface SnippetStore {
 
     /** Removes the record by id; missing id is a no-op. */
     fun remove(id: String)
+
+    /**
+     * Atomically computes and applies an order/content transform across all snippets.
+     * Implementations must ensure atomicity (e.g., via transaction) and preserve the id set.
+     */
+    fun reorder(transform: (List<Snippet>) -> List<Snippet>)
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetStore.kt
@@ -5,7 +5,7 @@ package app.skerry.shared.snippet
  * mutations. Implementations must be thread-safe.
  */
 interface SnippetStore {
-    /** All snippets in insertion/update order. */
+    /** All snippets in library order: what [reorder] last set, then anything it doesn't cover. */
     fun all(): List<Snippet>
 
     /** Creates a new record or replaces the existing one with the same [Snippet.id] (upsert). */
@@ -15,8 +15,16 @@ interface SnippetStore {
     fun remove(id: String)
 
     /**
-     * Atomically computes and applies an order/content transform across all snippets.
-     * Implementations must ensure atomicity (e.g., via transaction) and preserve the id set.
+     * Atomic reorder: [transform] receives the library in its current order and returns the new one
+     * (with updated [Snippet.group] when moving between folders). Read, compute and write happen
+     * under one lock, so an order computed from a stale snapshot can't clobber a concurrent write
+     * (a merge from background sync). The id set must not change: implementations reject a result
+     * that lost, gained or duplicated an entry, and the error must not carry the [Snippet] values
+     * themselves — they hold commands.
+     *
+     * Content changes in the result are saved either way, but the new order itself is dropped when
+     * the store cannot read where it keeps it — a caller that shows the order back to the user has
+     * to expect it to come back as it was on the next read.
      */
     fun reorder(transform: (List<Snippet>) -> List<Snippet>)
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/VaultSnippetStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/VaultSnippetStore.kt
@@ -4,34 +4,66 @@ import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.TrashStore
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecordCodec
+import app.skerry.shared.vault.WorkspaceLayoutStore
 
 /**
  * [SnippetStore] over an encrypted [Vault]: each snippet is a [RecordType.SNIPPET] record whose
  * payload is the JSON serialization of [Snippet]. Commands may contain inline credentials, so they
  * get the same encryption and E2E sync as other secrets.
  *
- * Snippets have no defined order (the interface has set semantics), so no separate order record
- * is needed; entries come back in [Vault.records] order. Reading a locked vault returns an empty
- * list; a corrupt payload is silently skipped.
+ * Order is stored in [WorkspaceLayout] to preserve manual drag-and-drop ordering across sync and
+ * sessions. Reading a locked vault returns an empty list; a corrupt payload is silently skipped.
  */
 class VaultSnippetStore(
     private val vault: Vault,
     /** Trash to snapshot deletions into; opt-in — see [app.skerry.shared.host.VaultHostStore]. */
     trash: TrashStore? = null,
+    private val layout: WorkspaceLayoutStore = WorkspaceLayoutStore(vault),
 ) : SnippetStore {
 
     private val codec = VaultRecordCodec(vault, RecordType.SNIPPET, Snippet.serializer(), trash) { it.label }
 
     override fun all(): List<Snippet> {
         if (!vault.isUnlocked) return emptyList()
-        return codec.list()
+        val snippets = codec.list()
+        val order = layout.read().snippetOrder
+        if (order.isEmpty()) return snippets
+        val rank = order.withIndex().associate { (i, id) -> id to i }
+        return snippets.sortedBy { rank[it.id] ?: Int.MAX_VALUE }
     }
 
-    override fun put(snippet: Snippet) {
+    override fun put(snippet: Snippet) = vault.transaction {
         codec.put(snippet.id, snippet)
+        val current = layout.readOrNull() ?: return@transaction
+        if (current.snippetOrder.isEmpty()) {
+            // Migration: seed with all existing snippets in codec order, then append the new one
+            val existingIds = codec.list().map { it.id }
+            layout.write(current.copy(snippetOrder = existingIds + snippet.id))
+        } else if (snippet.id !in current.snippetOrder) {
+            layout.write(current.copy(snippetOrder = current.snippetOrder + snippet.id))
+        }
     }
 
-    override fun remove(id: String) {
+    override fun remove(id: String) = vault.transaction {
         codec.remove(id)
+        val current = layout.readOrNull() ?: return@transaction
+        if (id in current.snippetOrder) {
+            layout.write(current.copy(snippetOrder = current.snippetOrder - id))
+        }
+    }
+
+    override fun reorder(transform: (List<Snippet>) -> List<Snippet>) = vault.transaction {
+        val current = all()
+        val updated = transform(current)
+        require(updated.size == current.size && updated.map { it.id }.toSet() == current.map { it.id }.toSet()) {
+            "reorder must preserve the id set (had ${current.size}, got ${updated.size})"
+        }
+        val byId = current.associateBy { it.id }
+        for (snippet in updated) {
+            if (byId[snippet.id] != snippet) codec.put(snippet.id, snippet)
+        }
+        val existing = layout.readOrNull() ?: return@transaction
+        val order = updated.map { it.id }
+        if (order != existing.snippetOrder) layout.write(existing.copy(snippetOrder = order))
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/VaultSnippetStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/VaultSnippetStore.kt
@@ -1,69 +1,79 @@
 package app.skerry.shared.snippet
 
+import app.skerry.shared.vault.LibraryOrderStore
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.TrashStore
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecordCodec
-import app.skerry.shared.vault.WorkspaceLayoutStore
+import app.skerry.shared.vault.requireSameIds
+import app.skerry.shared.vault.sortedByOrder
 
 /**
  * [SnippetStore] over an encrypted [Vault]: each snippet is a [RecordType.SNIPPET] record whose
  * payload is the JSON serialization of [Snippet]. Commands may contain inline credentials, so they
  * get the same encryption and E2E sync as other secrets.
  *
- * Order is stored in [WorkspaceLayout] to preserve manual drag-and-drop ordering across sync and
- * sessions. Reading a locked vault returns an empty list; a corrupt payload is silently skipped.
+ * Library order is stored apart, in [app.skerry.shared.vault.LibraryOrder] — [Vault.records] order
+ * can't be relied on for it (putting an existing record doesn't move it, and a merge arrives in
+ * server_seq order), which is the same reason the host tree has [app.skerry.shared.vault.WorkspaceLayout].
+ * Reading a locked vault returns an empty list; a corrupt payload is silently skipped.
  */
 class VaultSnippetStore(
     private val vault: Vault,
     /** Trash to snapshot deletions into; opt-in — see [app.skerry.shared.host.VaultHostStore]. */
     trash: TrashStore? = null,
-    private val layout: WorkspaceLayoutStore = WorkspaceLayoutStore(vault),
+    private val order: LibraryOrderStore = LibraryOrderStore(vault),
 ) : SnippetStore {
 
     private val codec = VaultRecordCodec(vault, RecordType.SNIPPET, Snippet.serializer(), trash) { it.label }
 
     override fun all(): List<Snippet> {
         if (!vault.isUnlocked) return emptyList()
-        val snippets = codec.list()
-        val order = layout.read().snippetOrder
-        if (order.isEmpty()) return snippets
-        val rank = order.withIndex().associate { (i, id) -> id to i }
-        return snippets.sortedBy { rank[it.id] ?: Int.MAX_VALUE }
+        return codec.list().sortedByOrder(order.read().snippets) { it.id }
     }
 
-    override fun put(snippet: Snippet) = vault.transaction {
+    /**
+     * Saves the snippet and leaves the order record alone: an id the order doesn't mention sorts
+     * to the end of the library ([sortedByOrder]), which is where a new snippet belongs. That is
+     * also what carries a library written before the order record existed — it keeps the order it
+     * has until the user drags something, instead of sinking below the first snippet added after
+     * the upgrade.
+     */
+    override fun put(snippet: Snippet) {
         codec.put(snippet.id, snippet)
-        val current = layout.readOrNull() ?: return@transaction
-        if (current.snippetOrder.isEmpty()) {
-            // Migration: seed with all existing snippets in codec order, then append the new one
-            val existingIds = codec.list().map { it.id }
-            layout.write(current.copy(snippetOrder = existingIds + snippet.id))
-        } else if (snippet.id !in current.snippetOrder) {
-            layout.write(current.copy(snippetOrder = current.snippetOrder + snippet.id))
-        }
     }
 
     override fun remove(id: String) = vault.transaction {
+        // Removal and the order update under one vault lock (like [reorder]): a mergeRemote from
+        // background sync landing between the read and the write would otherwise be clobbered.
         codec.remove(id)
-        val current = layout.readOrNull() ?: return@transaction
-        if (id in current.snippetOrder) {
-            layout.write(current.copy(snippetOrder = current.snippetOrder - id))
-        }
+        // readOrNull, not read: an order record that exists but cannot be decrypted reads as an
+        // empty order, and writing over it would drop the runbook order it also carries. The
+        // snippet is removed either way; only the bookkeeping is left as it is.
+        val current = order.readOrNull() ?: return@transaction
+        if (id in current.snippets) order.write(current.copy(snippets = current.snippets - id))
     }
 
     override fun reorder(transform: (List<Snippet>) -> List<Snippet>) = vault.transaction {
+        // Read-compute-write under one vault lock: a mergeRemote landing between the all() snapshot
+        // and the write below would be clobbered with an order computed from a stale list.
         val current = all()
         val updated = transform(current)
-        require(updated.size == current.size && updated.map { it.id }.toSet() == current.map { it.id }.toSet()) {
-            "reorder must preserve the id set (had ${current.size}, got ${updated.size})"
-        }
+        requireSameIds(current, updated) { it.id }
+        // Only snippets whose content actually changed (a folder move rewrites Snippet.group) — a
+        // pure reorder must not bump every record's version, that is sync traffic for nothing.
+        // A snippet whose payload this build cannot decode is not in `current` at all (codec.list
+        // skips it), so the order written below forgets where it sat — as the host tree does. It
+        // reappears at the end of the library once the payload can be read again.
         val byId = current.associateBy { it.id }
         for (snippet in updated) {
             if (byId[snippet.id] != snippet) codec.put(snippet.id, snippet)
         }
-        val existing = layout.readOrNull() ?: return@transaction
-        val order = updated.map { it.id }
-        if (order != existing.snippetOrder) layout.write(existing.copy(snippetOrder = order))
+        val existing = order.readOrNull() ?: return@transaction // see [remove]
+        // Only when the order actually moved: a content-only transform (renaming a folder) would
+        // otherwise bump the record on every call, and a device still holding an older order would
+        // push it back over a reorder made elsewhere.
+        val ids = updated.map { it.id }
+        if (ids != existing.snippets) order.write(existing.copy(snippets = ids))
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncEngine.kt
@@ -13,7 +13,10 @@ import kotlin.coroutines.cancellation.CancellationException
  * supported server release accepts it.
  */
 private val TYPES_NEWER_THAN_SOME_SERVERS =
-    setOf(RecordType.TRASH, RecordType.RUNBOOK, RecordType.RUNBOOK_RUN, RecordType.TRUSTED_CA, RecordType.TEAM_PEER)
+    setOf(
+        RecordType.TRASH, RecordType.RUNBOOK, RecordType.RUNBOOK_RUN, RecordType.TRUSTED_CA,
+        RecordType.TEAM_PEER, RecordType.LIBRARY_ORDER,
+    )
 
 /**
  * How a server that predates one of [TYPES_NEWER_THAN_SOME_SERVERS] answers a push carrying it:
@@ -136,29 +139,15 @@ class SyncEngine(
         // rejects a whole push batch on an unknown type, and losing hosts/keys/settings sync
         // because a trash snapshot or a trusted CA can't be mirrored would be a far worse trade.
         // Their rejection is swallowed — those records then stay device-local until the server is
-        // updated, and the next cycle retries (push-all sends them again anyway).
+        // updated, and the next cycle retries (push-all sends them again anyway). One refused type
+        // must not silence the rest of that batch either: see [pushOptional].
         val (recentTypes, records) = local.partition { it.type in TYPES_NEWER_THAN_SOME_SERVERS }
         var pushed = 0
         if (records.isNotEmpty()) {
             client.push(session, records.map { it.toRemote() })
             pushed += records.size
         }
-        if (recentTypes.isNotEmpty()) {
-            try {
-                client.push(session, recentTypes.map { it.toRemote() })
-                pushed += recentTypes.size
-            } catch (e: CancellationException) {
-                // A `runCatching` here caught this too, so a vault auto-lock or a disconnect landing
-                // inside the push left the engine running on a cancelled job through the second pull.
-                throw e
-            } catch (e: SyncException) {
-                // Only the two answers an older server gives to a type it does not know are
-                // swallowed. A 401, a 429, a 5xx or a dropped network say nothing about the record
-                // type, and hiding them made a batch that will never be accepted look exactly like
-                // one the server is merely too old for — so nothing was ever diagnosable.
-                if (e.kind !in OLD_SERVER_REFUSALS) throw e
-            }
-        }
+        if (recentTypes.isNotEmpty()) pushed += pushOptional(session, recentTypes)
 
         // Pull again: picks up our own just-pushed records (merge is idempotent) and any remote
         // changes with a serverSeq between the first pull and the push, so the cursor doesn't skip them.
@@ -167,6 +156,41 @@ class SyncEngine(
         state.setCursor(session.accountId, cursor)
         return SyncOutcome(pulled = pulled, pushed = pushed, cursor = cursor, rejected = rejected)
     }
+
+    /**
+     * The batch of [TYPES_NEWER_THAN_SOME_SERVERS], pushed whole while the server knows every type in
+     * it and retried one type at a time when it doesn't. The server rejects a whole batch on the
+     * first type it can't name, so a single type this deployment predates would otherwise silence
+     * every other type in the batch — including [RecordType.TEAM_PEER], the pin a seal is held to
+     * (#319), whose absence on a second device fails open. The retry costs one request per type and
+     * only on a server that refused, so nothing changes for a server that is current.
+     */
+    private suspend fun pushOptional(session: SyncSession, records: List<VaultRecord>): Int {
+        if (pushSwallowingOldServer(session, records)) return records.size
+        var pushed = 0
+        for (ofOneType in records.groupBy { it.type }.values) {
+            if (pushSwallowingOldServer(session, ofOneType)) pushed += ofOneType.size
+        }
+        return pushed
+    }
+
+    /** Pushes [records], answering false for the refusal an old server gives a type it doesn't know. */
+    private suspend fun pushSwallowingOldServer(session: SyncSession, records: List<VaultRecord>): Boolean =
+        try {
+            client.push(session, records.map { it.toRemote() })
+            true
+        } catch (e: CancellationException) {
+            // A `runCatching` here caught this too, so a vault auto-lock or a disconnect landing
+            // inside the push left the engine running on a cancelled job through the second pull.
+            throw e
+        } catch (e: SyncException) {
+            // Only the two answers an older server gives to a type it does not know are swallowed.
+            // A 401, a 429, a 5xx or a dropped network say nothing about the record type, and hiding
+            // them made a batch that will never be accepted look exactly like one the server is
+            // merely too old for — so nothing was ever diagnosable.
+            if (e.kind !in OLD_SERVER_REFUSALS) throw e
+            false
+        }
 
     /** Pulls delta pages until exhausted (for future pagination), merging each page into the vault. */
     private suspend fun drainPull(session: SyncSession, from: Long, onMerged: (MergeResult) -> Unit): Long {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncSettings.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncSettings.kt
@@ -43,7 +43,9 @@ data class SyncSettings(
         RecordType.TEAM, RecordType.TEAM_IDENTITY, RecordType.TEAM_PEER -> true
         // A runbook is a checklist of the same commands, saved and shared for the same reasons, so
         // it follows the snippets toggle instead of adding a switch nobody would set differently.
-        RecordType.SNIPPET, RecordType.RUNBOOK, RecordType.RUNBOOK_RUN -> syncSnippets
+        // The library order is a list of snippet and runbook ids and nothing else, so it follows
+        // them: with snippets off, the ids of records that never leave the device don't either.
+        RecordType.SNIPPET, RecordType.RUNBOOK, RecordType.RUNBOOK_RUN, RecordType.LIBRARY_ORDER -> syncSnippets
         RecordType.HOST,
         RecordType.GROUP,
         RecordType.IDENTITY,

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/LibraryOrder.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/LibraryOrder.kt
@@ -1,0 +1,61 @@
+package app.skerry.shared.vault
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Manual order of the snippet and runbook libraries: the id lists the user dragged into place,
+ * synced as a single [RecordType.LIBRARY_ORDER] record with reserved id [LibraryOrderStore.ORDER_ID].
+ * Ids the lists don't mention keep their [Vault.records] order and follow the ones that are in them
+ * (see [sortedByOrder]), so an account that never reordered anything has no record here at all and
+ * reads exactly as it did before the feature — no migration to run.
+ *
+ * Deliberately not a field of [WorkspaceLayout]: that record is the whole account's host tree and
+ * it travels as one blob under LWW, so a snippet dragged in the library would be able to carry a
+ * stale host order to every device. The two libraries share this record because they share a screen
+ * and a sync toggle; between the two of them LWW can only cost the order of the other list.
+ */
+@Serializable
+data class LibraryOrder(
+    /** Global order of snippet ids in the library. */
+    val snippets: List<String> = emptyList(),
+    /** Global order of runbook ids in the library. */
+    val runbooks: List<String> = emptyList(),
+)
+
+/**
+ * Reads/writes the single [LibraryOrder] record, following [WorkspaceLayoutStore]. Holds no state
+ * of its own, so [app.skerry.shared.snippet.VaultSnippetStore] and
+ * [app.skerry.shared.runbook.VaultRunbookStore] each keep their own instance; what makes their
+ * read-modify-writes safe against each other and against background sync is that both run inside
+ * [Vault.transaction], not a shared object. Locked or absent vault → empty order.
+ */
+class LibraryOrderStore(private val vault: Vault) {
+
+    private val store = VaultSingletonStore(vault, ORDER_ID, RecordType.LIBRARY_ORDER, LibraryOrder.serializer()) {
+        LibraryOrder()
+    }
+
+    fun read(): LibraryOrder = store.load()
+
+    /**
+     * The order, or null when the record exists and cannot be read — see
+     * [WorkspaceLayoutStore.readOrNull]. A writer that cannot tell an unreadable record from a
+     * missing one replaces the other library's order with whatever it happens to hold, and LWW
+     * carries the replacement to every device. Callers that write skip the update instead.
+     */
+    fun readOrNull(): LibraryOrder? = store.loadOrNull()
+
+    fun write(order: LibraryOrder) {
+        store.save(order)
+    }
+
+    companion object {
+        /**
+         * Reserved id of the library-order record, prefixed like [WorkspaceLayoutStore.LAYOUT_ID].
+         * Not every id in the vault is this client's to choose — a team id is whatever the server
+         * answered with — and an id belongs to one record type for its whole life, so an unprefixed
+         * name is one a server could hand back and make the next write throw.
+         */
+        const val ORDER_ID = "skerry.library.order"
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/RecordOrder.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/RecordOrder.kt
@@ -1,0 +1,27 @@
+package app.skerry.shared.vault
+
+/**
+ * Sorts records by an explicit list of ids. Stable: an id the order doesn't mention keeps its
+ * relative [Vault.records] position and lands after everything the order does mention — which is
+ * where a record created or merged since the order was last written belongs, and why creating one
+ * doesn't have to write the order at all.
+ */
+internal fun <T> List<T>.sortedByOrder(order: List<String>, id: (T) -> String): List<T> {
+    if (order.isEmpty()) return this
+    val rank = order.withIndex().associate { (i, recordId) -> recordId to i }
+    return sortedBy { rank[id(it)] ?: Int.MAX_VALUE }
+}
+
+/**
+ * Rejects a reorder transform that changed the id set. Size **and** set: set equality alone misses
+ * a duplicate (`[A, B, C, A]`), and a duplicated id corrupts the stored order — `associate` above
+ * keeps the last index for it. A lost id is worse still: for a host it is a lost secret reference.
+ *
+ * The message carries counts only. The records themselves hold commands and credential references,
+ * and this one travels into logs and crash reports.
+ */
+internal fun <T> requireSameIds(current: List<T>, updated: List<T>, id: (T) -> String) {
+    require(updated.size == current.size && updated.mapTo(mutableSetOf(), id) == current.mapTo(mutableSetOf(), id)) {
+        "reorder must preserve the id set (had ${current.size}, got ${updated.size})"
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultRecord.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultRecord.kt
@@ -39,6 +39,13 @@ enum class RecordType {
     TEAM_PEER,
 
     /**
+     * Manual order of the snippet and runbook libraries — one record, see
+     * [app.skerry.shared.vault.LibraryOrder]. A type of its own rather than a field of the layout
+     * record: it follows the snippets sync toggle, not the hosts one.
+     */
+    LIBRARY_ORDER,
+
+    /**
      * Snapshot of a deleted record kept for the trash window (see [app.skerry.shared.vault.TrashStore]).
      * A separate type, not a fatter tombstone: tombstones stay empty, and clients that don't know
      * this type keep the record verbatim without ever showing it.

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/WorkspaceLayout.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/WorkspaceLayout.kt
@@ -26,6 +26,10 @@ data class WorkspaceLayout(
      * list.
      */
     val remoteDesktopGroups: List<String> = emptyList(),
+    /** Global order of snippet ids in the library. */
+    val snippetOrder: List<String> = emptyList(),
+    /** Global order of runbook ids in the library. */
+    val runbookOrder: List<String> = emptyList(),
 )
 
 /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/WorkspaceLayout.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/WorkspaceLayout.kt
@@ -26,10 +26,6 @@ data class WorkspaceLayout(
      * list.
      */
     val remoteDesktopGroups: List<String> = emptyList(),
-    /** Global order of snippet ids in the library. */
-    val snippetOrder: List<String> = emptyList(),
-    /** Global order of runbook ids in the library. */
-    val runbookOrder: List<String> = emptyList(),
 )
 
 /**

--- a/shared/src/commonTest/kotlin/app/skerry/shared/runbook/VaultRunbookStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/runbook/VaultRunbookStoreTest.kt
@@ -66,4 +66,20 @@ class VaultRunbookStoreTest {
         assertEquals("Drain", stored.label)
         assertNull(stored.group)
     }
+
+    @Test
+    fun `reorder updates and persists order in layout`() {
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1"))
+        store.put(runbook("r2"))
+        store.put(runbook("r3"))
+
+        assertEquals(listOf("r1", "r2", "r3"), store.all().map { it.id })
+
+        store.reorder { listOf(it[2], it[0], it[1]) }
+
+        val freshStore = VaultRunbookStore(vault)
+        assertEquals(listOf("r3", "r1", "r2"), freshStore.all().map { it.id })
+    }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/runbook/VaultRunbookStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/runbook/VaultRunbookStoreTest.kt
@@ -1,10 +1,16 @@
 package app.skerry.shared.runbook
 
+import app.skerry.shared.snippet.Snippet
+import app.skerry.shared.snippet.VaultSnippetStore
 import app.skerry.shared.vault.FakeVault
+import app.skerry.shared.vault.LibraryOrderStore
 import app.skerry.shared.vault.RecordType
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class VaultRunbookStoreTest {
 
@@ -68,18 +74,137 @@ class VaultRunbookStoreTest {
     }
 
     @Test
-    fun `reorder updates and persists order in layout`() {
+    fun `reorder persists the library order across store instances`() {
         val vault = FakeVault()
         val store = VaultRunbookStore(vault)
-        store.put(runbook("r1"))
-        store.put(runbook("r2"))
-        store.put(runbook("r3"))
-
+        store.put(runbook("r1")); store.put(runbook("r2")); store.put(runbook("r3"))
         assertEquals(listOf("r1", "r2", "r3"), store.all().map { it.id })
 
         store.reorder { listOf(it[2], it[0], it[1]) }
 
-        val freshStore = VaultRunbookStore(vault)
-        assertEquals(listOf("r3", "r1", "r2"), freshStore.all().map { it.id })
+        assertEquals(listOf("r3", "r1", "r2"), VaultRunbookStore(vault).all().map { it.id })
+    }
+
+    /** See [app.skerry.shared.snippet.VaultSnippetStoreTest]: a saved runbook writes no order. */
+    @Test
+    fun `saving a runbook writes no order record and keeps the order of a library that has none`() {
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1")); store.put(runbook("r2")); store.put(runbook("r3"))
+
+        store.put(runbook("r4"))
+
+        assertEquals(listOf("r1", "r2", "r3", "r4"), store.all().map { it.id })
+        assertFalse(
+            vault.records().any { it.id == LibraryOrderStore.ORDER_ID },
+            "a runbook nobody dragged wrote an order record",
+        )
+    }
+
+    @Test
+    fun `remove drops the id from the order`() {
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1")); store.put(runbook("r2"))
+        store.reorder { it.reversed() }
+
+        store.remove("r2")
+
+        assertEquals(listOf("r1"), LibraryOrderStore(vault).read().runbooks)
+        assertEquals(listOf("r1"), store.all().map { it.id })
+    }
+
+    @Test
+    fun `reorder rejects a lost or duplicated runbook`() {
+        val store = VaultRunbookStore(FakeVault())
+        store.put(runbook("r1")); store.put(runbook("r2")); store.put(runbook("r3"))
+        assertFailsWith<IllegalArgumentException> { store.reorder { it.dropLast(1) } }
+        // Same id set, one entry twice: caught by the count, not by the set.
+        assertFailsWith<IllegalArgumentException> { store.reorder { it + it[0] } }
+    }
+
+    @Test
+    fun `a pure reorder does not bump runbook record versions`() {
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1")); store.put(runbook("r2"))
+        val before = vault.records().filter { it.type == RecordType.RUNBOOK }.associate { it.id to it.version }
+        store.reorder { it.reversed() }
+        val after = vault.records().filter { it.type == RecordType.RUNBOOK }.associate { it.id to it.version }
+        assertEquals(before, after, "a reorder rewrote records whose content never changed")
+    }
+
+    @Test
+    fun `reorder persists content changes like a folder move`() {
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1")); store.put(runbook("r2"))
+        store.reorder { list -> list.map { if (it.id == "r1") it.copy(group = "ops") else it } }
+        val reloaded = VaultRunbookStore(vault).all().associateBy { it.id }
+        assertEquals("ops", reloaded.getValue("r1").group)
+        assertNull(reloaded.getValue("r2").group)
+    }
+
+    @Test
+    fun `an unreadable order record is left alone instead of being overwritten`() {
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1")); store.put(runbook("r2"))
+        store.reorder { it.reversed() }
+        // See the snippet twin: only the other library's list can tell an overwrite from a skip.
+        val snippets = VaultSnippetStore(vault)
+        snippets.put(Snippet(id = "s1", label = "Disk", command = "df -h"))
+        snippets.put(Snippet(id = "s2", label = "Load", command = "uptime"))
+        snippets.reorder { it.reversed() }
+
+        vault.unreadable += LibraryOrderStore.ORDER_ID
+        store.reorder { it.reversed() }
+        store.remove("r1")
+        vault.unreadable -= LibraryOrderStore.ORDER_ID
+
+        assertEquals(listOf("r2", "r1"), LibraryOrderStore(vault).read().runbooks)
+        assertEquals(listOf("s2", "s1"), LibraryOrderStore(vault).read().snippets, "the snippet order was overwritten")
+    }
+
+    /** See the snippet twin: an id the order doesn't mention ranks last, which is why [put] writes none. */
+    @Test
+    fun `a runbook created after a reorder lands at the end of the library`() {
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1")); store.put(runbook("r2")); store.put(runbook("r3"))
+        store.reorder { it.reversed() }
+
+        store.put(runbook("r4"))
+
+        assertEquals(listOf("r3", "r2", "r1", "r4"), store.all().map { it.id })
+    }
+
+    @Test
+    fun `a content-only reorder does not bump the order record`() {
+        // The record is the order of both libraries under LWW: bumping it on a transform that only
+        // rewrote a field would let a device holding an older order push it back over a reorder
+        // made elsewhere.
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1")); store.put(runbook("r2"))
+        store.reorder { it.reversed() }
+        val before = vault.records().single { it.id == LibraryOrderStore.ORDER_ID }.version
+        store.reorder { list -> list.map { if (it.id == "r1") it.copy(group = "ops") else it } }
+        val after = vault.records().single { it.id == LibraryOrderStore.ORDER_ID }.version
+        assertEquals(before, after)
+    }
+
+    /** See the snippet twin: read and write have to share one transaction, or a merge lands between. */
+    @Test
+    fun `reorder reads and writes under one transaction`() {
+        val vault = FakeVault()
+        val store = VaultRunbookStore(vault)
+        store.put(runbook("r1")); store.put(runbook("r2"))
+
+        val readsBefore = vault.readsOutsideTransaction
+        store.reorder { it.reversed() }
+
+        assertEquals(readsBefore, vault.readsOutsideTransaction, "the library was read outside the transaction")
+        assertTrue(vault.lastPutInTransaction, "the order was written outside the transaction")
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/snippet/VaultSnippetStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/snippet/VaultSnippetStoreTest.kt
@@ -58,4 +58,20 @@ class VaultSnippetStoreTest {
         assertEquals("Disk", stored.label)
         assertNull(stored.group)
     }
+
+    @Test
+    fun `reorder updates and persists order in layout`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1"))
+        store.put(snippet("s2"))
+        store.put(snippet("s3"))
+
+        assertEquals(listOf("s1", "s2", "s3"), store.all().map { it.id })
+
+        store.reorder { listOf(it[2], it[0], it[1]) }
+
+        val freshStore = VaultSnippetStore(vault)
+        assertEquals(listOf("s3", "s1", "s2"), freshStore.all().map { it.id })
+    }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/snippet/VaultSnippetStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/snippet/VaultSnippetStoreTest.kt
@@ -1,10 +1,18 @@
 package app.skerry.shared.snippet
 
+import app.skerry.shared.runbook.Runbook
+import app.skerry.shared.runbook.VaultRunbookStore
 import app.skerry.shared.vault.FakeVault
+import app.skerry.shared.vault.LibraryOrderStore
 import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.TrashStore
+import app.skerry.shared.vault.WorkspaceLayoutStore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class VaultSnippetStoreTest {
 
@@ -60,18 +68,203 @@ class VaultSnippetStoreTest {
     }
 
     @Test
-    fun `reorder updates and persists order in layout`() {
+    fun `reorder persists the library order across store instances`() {
         val vault = FakeVault()
         val store = VaultSnippetStore(vault)
-        store.put(snippet("s1"))
-        store.put(snippet("s2"))
-        store.put(snippet("s3"))
-
+        store.put(snippet("s1")); store.put(snippet("s2")); store.put(snippet("s3"))
         assertEquals(listOf("s1", "s2", "s3"), store.all().map { it.id })
 
         store.reorder { listOf(it[2], it[0], it[1]) }
 
-        val freshStore = VaultSnippetStore(vault)
-        assertEquals(listOf("s3", "s1", "s2"), freshStore.all().map { it.id })
+        assertEquals(listOf("s3", "s1", "s2"), VaultSnippetStore(vault).all().map { it.id })
+    }
+
+    /**
+     * The order record is written by a drag and by nothing else. Saving a snippet that appends an
+     * id to an empty order is what would sink a whole pre-feature library below the first snippet
+     * added after the upgrade — the sort puts an id the order doesn't mention last for free.
+     */
+    @Test
+    fun `saving a snippet writes no order record and keeps the order of a library that has none`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1")); store.put(snippet("s2")); store.put(snippet("s3"))
+
+        store.put(snippet("s4"))
+
+        assertEquals(listOf("s1", "s2", "s3", "s4"), store.all().map { it.id })
+        assertFalse(
+            vault.records().any { it.id == LibraryOrderStore.ORDER_ID },
+            "a snippet nobody dragged wrote an order record",
+        )
+    }
+
+    /**
+     * The host tree is a record of its own, and it travels between devices as one blob under LWW.
+     * A snippet saved on a device holding a stale host order must not be able to push that order
+     * back over a reorder made somewhere else.
+     */
+    @Test
+    fun `snippet writes never touch the workspace layout`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1")); store.put(snippet("s2"))
+        store.reorder { it.reversed() }
+        store.remove("s1")
+
+        assertFalse(
+            vault.records().any { it.id == WorkspaceLayoutStore.LAYOUT_ID },
+            "the library order was written into the host tree record",
+        )
+    }
+
+    @Test
+    fun `remove drops the id from the order`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1")); store.put(snippet("s2"))
+        store.reorder { it.reversed() }
+
+        store.remove("s2")
+
+        assertEquals(listOf("s1"), LibraryOrderStore(vault).read().snippets)
+        assertEquals(listOf("s1"), store.all().map { it.id })
+    }
+
+    @Test
+    fun `reorder rejects a lost or duplicated snippet`() {
+        val store = VaultSnippetStore(FakeVault())
+        store.put(snippet("s1")); store.put(snippet("s2")); store.put(snippet("s3"))
+        assertFailsWith<IllegalArgumentException> { store.reorder { it.dropLast(1) } }
+        // Same id set, one entry twice: caught by the count, not by the set.
+        assertFailsWith<IllegalArgumentException> { store.reorder { it + it[0] } }
+    }
+
+    @Test
+    fun `a pure reorder does not bump snippet record versions`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1")); store.put(snippet("s2"))
+        val before = vault.records().filter { it.type == RecordType.SNIPPET }.associate { it.id to it.version }
+        store.reorder { it.reversed() }
+        val after = vault.records().filter { it.type == RecordType.SNIPPET }.associate { it.id to it.version }
+        assertEquals(before, after, "a reorder rewrote records whose content never changed")
+    }
+
+    @Test
+    fun `reorder persists content changes like a folder move`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1")); store.put(snippet("s2"))
+        store.reorder { list -> list.map { if (it.id == "s1") it.copy(group = "ops") else it } }
+        val reloaded = VaultSnippetStore(vault).all().associateBy { it.id }
+        assertEquals("ops", reloaded.getValue("s1").group)
+        assertNull(reloaded.getValue("s2").group)
+    }
+
+    @Test
+    fun `a content-only reorder does not bump the order record`() {
+        // The record is the whole library's order under LWW: bumping it on a transform that only
+        // rewrote a field (renaming a folder) would let a device holding an older order push it
+        // back over a reorder made elsewhere.
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1")); store.put(snippet("s2"))
+        store.reorder { it.reversed() }
+        val before = vault.records().single { it.id == LibraryOrderStore.ORDER_ID }.version
+        store.reorder { list -> list.map { if (it.id == "s1") it.copy(group = "ops") else it } }
+        val after = vault.records().single { it.id == LibraryOrderStore.ORDER_ID }.version
+        assertEquals(before, after)
+    }
+
+    /**
+     * A record that exists and no longer decrypts (what adopting an account dataKey leaves behind)
+     * reads as "no order at all". Writing over it would drop the runbook order it also carries, and
+     * LWW would carry the loss to every device.
+     */
+    @Test
+    fun `an unreadable order record is left alone instead of being overwritten`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1")); store.put(snippet("s2"))
+        store.reorder { it.reversed() }
+        // The runbook order shares the record and is what a blind write would destroy: the snippet
+        // list a reverted store writes back is the one it just computed, so only the other library
+        // can tell an overwrite from a skip.
+        val runbooks = VaultRunbookStore(vault)
+        runbooks.put(Runbook(id = "r1", label = "Drain")); runbooks.put(Runbook(id = "r2", label = "Deploy"))
+        runbooks.reorder { it.reversed() }
+
+        vault.unreadable += LibraryOrderStore.ORDER_ID
+        store.reorder { it.reversed() }
+        store.remove("s1")
+        vault.unreadable -= LibraryOrderStore.ORDER_ID
+
+        assertEquals(listOf("s2", "s1"), LibraryOrderStore(vault).read().snippets)
+        assertEquals(listOf("r2", "r1"), LibraryOrderStore(vault).read().runbooks, "the runbook order was overwritten")
+    }
+
+    /**
+     * The reason [put] writes no order at all: an id the order doesn't mention ranks last. Revert
+     * that fallback and every snippet created after a drag jumps to the top of the library.
+     */
+    @Test
+    fun `a snippet created after a reorder lands at the end of the library`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1")); store.put(snippet("s2")); store.put(snippet("s3"))
+        store.reorder { it.reversed() }
+
+        store.put(snippet("s4"))
+
+        assertEquals(listOf("s3", "s2", "s1", "s4"), store.all().map { it.id })
+    }
+
+    @Test
+    fun `a locked vault reads as empty instead of throwing`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1"))
+        store.reorder { it }
+
+        vault.locked = true
+
+        assertEquals(emptyList(), store.all())
+    }
+
+    /**
+     * The order is read and written inside the same [app.skerry.shared.vault.Vault.transaction] as
+     * the records: a store that reads outside it and writes inside still lets a mergeRemote from
+     * background sync land in between and be clobbered by an order computed from the stale snapshot.
+     */
+    @Test
+    fun `reorder reads and writes under one transaction`() {
+        val vault = FakeVault()
+        val store = VaultSnippetStore(vault)
+        store.put(snippet("s1")); store.put(snippet("s2"))
+
+        val readsBefore = vault.readsOutsideTransaction
+        store.reorder { it.reversed() }
+
+        assertEquals(readsBefore, vault.readsOutsideTransaction, "the library was read outside the transaction")
+        assertTrue(vault.lastPutInTransaction, "the order was written outside the transaction")
+    }
+
+    /**
+     * The trash restores the record, not its place: [remove] dropped the id from the order, and the
+     * restore path writes the record straight into the vault. The snippet is back, at the end.
+     */
+    @Test
+    fun `a snippet restored from the trash comes back at the end of the library`() {
+        val vault = FakeVault()
+        val trash = TrashStore(vault)
+        val store = VaultSnippetStore(vault, trash)
+        store.put(snippet("s1")); store.put(snippet("s2")); store.put(snippet("s3"))
+        store.reorder { it.reversed() }
+
+        store.remove("s2")
+        assertTrue(trash.restore(trash.entries().single().recordId))
+
+        assertEquals(listOf("s3", "s1", "s2"), store.all().map { it.id })
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/sync/SyncSettingsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/sync/SyncSettingsTest.kt
@@ -22,6 +22,10 @@ class SyncSettingsTest {
         val s = SyncSettings(syncSnippets = false)
         assertFalse(s.shouldSync(RecordType.SNIPPET))
         assertFalse(s.shouldSync(RecordType.RUNBOOK), "runbooks follow the snippets toggle")
+        assertFalse(
+            s.shouldSync(RecordType.LIBRARY_ORDER),
+            "the library order is a list of snippet and runbook ids and follows them",
+        )
         assertTrue(s.shouldSync(RecordType.HOST))
         assertTrue(s.shouldSync(RecordType.SETTINGS), "settings record always syncs")
     }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
@@ -146,11 +146,12 @@ class CredentialStoreTest {
         // A plain put is a single call and holds no transaction — the control for the assertion below.
         assertFalse(vault.lastPutInTransaction)
 
+        val readsBefore = vault.readsOutsideTransaction
         store.edit("c-1", "new", note = null, group = null)
 
         // edit's read AND its put must run under a held transaction, or a concurrent mergeRemote can
         // slip a tombstone between them (TOCTOU resurrection across all synced devices).
-        assertTrue(vault.lastReadInTransaction)
+        assertEquals(readsBefore, vault.readsOutsideTransaction, "the record was read outside the transaction")
         assertTrue(vault.lastPutInTransaction)
     }
 
@@ -228,11 +229,12 @@ class CredentialStoreTest {
         // A plain put holds no transaction — the control, as in the `edit` case above.
         assertFalse(vault.lastPutInTransaction)
 
+        val readsBefore = vault.readsOutsideTransaction
         store.putKeepingMeta(Credential("c-1", "temp key", CredentialSecret.Password("y")))
 
         // Both halves: a merge landing a tombstone between a read taken outside the transaction and
         // the write inside it would still raise the deleted secret on every device.
-        assertTrue(vault.lastReadInTransaction)
+        assertEquals(readsBefore, vault.readsOutsideTransaction, "the record was read outside the transaction")
         assertTrue(vault.lastPutInTransaction)
     }
 

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
@@ -30,11 +30,16 @@ internal class FakeVault : Vault {
         private set
 
     /**
-     * Whether the most recent record read happened while a [transaction] was held. A store that reads
-     * outside the transaction and writes inside it still passes [lastPutInTransaction] while leaving
-     * the check-then-write race wide open, which is the whole point of holding one.
+     * How many record reads happened with no [transaction] held. A store that reads outside the
+     * transaction and writes inside it still passes [lastPutInTransaction] while leaving the
+     * check-then-write race wide open, which is the whole point of holding one.
+     *
+     * A counter and not a "was the last read in a transaction" flag: the last read of a
+     * read-compute-write is the one right before the write, and that one sits inside the block in
+     * every implementation — including the racy one, where the snapshot it recomputes from was taken
+     * outside. Only counting the reads that escaped can tell the two apart.
      */
-    var lastReadInTransaction: Boolean = false
+    var readsOutsideTransaction: Int = 0
         private set
 
     override fun <T> transaction(block: () -> T): T {
@@ -54,7 +59,7 @@ internal class FakeVault : Vault {
     override fun reset() { entries.clear() }
 
     override fun records(): List<VaultRecord> {
-        lastReadInTransaction = transactionDepth > 0
+        if (transactionDepth == 0) readsOutsideTransaction++
         return entries.values.map { it.record }
     }
 
@@ -62,7 +67,7 @@ internal class FakeVault : Vault {
     override fun mergeRemote(remote: List<VaultRecord>): MergeResult = MergeResult.EMPTY
 
     override fun openPayload(id: String): ByteArray? {
-        lastReadInTransaction = transactionDepth > 0
+        if (transactionDepth == 0) readsOutsideTransaction++
         return if (id in unreadable) null else entries[id]?.takeIf { !it.record.deleted }?.payload
     }
 

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/LibraryOrderStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/LibraryOrderStoreTest.kt
@@ -1,0 +1,94 @@
+package app.skerry.shared.vault
+
+import app.skerry.shared.runbook.Runbook
+import app.skerry.shared.runbook.VaultRunbookStore
+import app.skerry.shared.snippet.Snippet
+import app.skerry.shared.snippet.VaultSnippetStore
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** The two libraries share one order record, so each has to leave the other's list where it is. */
+class LibraryOrderStoreTest {
+
+    @Test
+    fun `reordering one library keeps the order of the other`() {
+        val vault = FakeVault()
+        val runbooks = VaultRunbookStore(vault)
+        runbooks.put(Runbook(id = "r1", label = "Drain"))
+        runbooks.put(Runbook(id = "r2", label = "Deploy"))
+        runbooks.reorder { it.reversed() }
+
+        val snippets = VaultSnippetStore(vault)
+        snippets.put(Snippet(id = "s1", label = "Disk", command = "df -h"))
+        snippets.put(Snippet(id = "s2", label = "Load", command = "uptime"))
+        snippets.reorder { it.reversed() }
+        snippets.remove("s2")
+
+        val order = LibraryOrderStore(vault).read()
+        assertEquals(listOf("r2", "r1"), order.runbooks, "the snippet library rewrote the runbook order")
+        assertEquals(listOf("s1"), order.snippets)
+    }
+
+    @Test
+    fun `saving into either library writes no order record`() {
+        val vault = FakeVault()
+        VaultSnippetStore(vault).put(Snippet(id = "s1", label = "Disk", command = "df -h"))
+        VaultRunbookStore(vault).put(Runbook(id = "r1", label = "Drain"))
+
+        assertEquals(
+            emptyList(),
+            vault.records().filter { it.type == RecordType.LIBRARY_ORDER }.map { it.id },
+            "an untouched library wrote an order record",
+        )
+    }
+
+    /**
+     * One record holds both lists, so LWW resolves them together: two devices reordering different
+     * libraries offline do not merge, the newer record wins whole. The cost is meant to be the loser
+     * reverting to the winner's view of its list — never a list that comes back short, empty, or
+     * carrying the other library's ids.
+     */
+    @Test
+    fun `a newer order from another device replaces both lists rather than merging them`() = runTest {
+        initializeVaultCrypto()
+        val crypto = IonspinVaultCrypto()
+        val fs = FakeFileSystem()
+        val a = FileVault("/a.json".toPath(), crypto, "device-a", fs) { TS }
+            .apply { create("master".toCharArray()) }
+        val b = FileVault("/b.json".toPath(), crypto, "device-b", fs) { TS }
+            .apply { createWithDataKey(a.exportDataKey()!!) }
+
+        val snippetsA = VaultSnippetStore(a)
+        listOf("s1", "s2", "s3").forEach { snippetsA.put(Snippet(id = it, label = it, command = "true")) }
+        val runbooksA = VaultRunbookStore(a)
+        listOf("r1", "r2").forEach { runbooksA.put(Runbook(id = it, label = it)) }
+        // Both devices start from the same order record, runbooks included — the winner has to carry
+        // a runbook order of its own, or the assertion below cannot tell "the winner's list" from
+        // "no list at all, so record order".
+        runbooksA.reorder { it.reversed() }
+        b.mergeRemote(a.records())
+
+        // Device A reorders its snippets twice, so its record is at version 3 against B's 2 and the
+        // winner is fixed by version — the deviceId tie-break would have picked B.
+        snippetsA.reorder { it.reversed() }
+        snippetsA.reorder { listOf(it[1], it[0], it[2]) }
+        // Device B, offline, reorders the other library — the half LWW is about to drop.
+        VaultRunbookStore(b).reorder { it.reversed() }
+
+        b.mergeRemote(a.records())
+
+        assertEquals(listOf("s2", "s3", "s1"), VaultSnippetStore(b).all().map { it.id })
+        assertEquals(
+            listOf("r2", "r1"),
+            VaultRunbookStore(b).all().map { it.id },
+            "the losing library must fall back to the winner's order, not lose its entries",
+        )
+    }
+
+    private companion object {
+        const val TS = "2026-06-29T00:00:00Z"
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/RecordOrderTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/RecordOrderTest.kt
@@ -1,0 +1,43 @@
+package app.skerry.shared.vault
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The stored order is a synced record: it can name ids that no longer exist, name one twice, or not
+ * name an id at all. None of that may lose or duplicate a record — the order only moves rows.
+ */
+class RecordOrderTest {
+
+    private data class Row(val id: String)
+
+    private val rows = listOf(Row("a"), Row("b"), Row("c"))
+
+    @Test
+    fun `an empty order leaves the list alone`() {
+        assertEquals(rows, rows.sortedByOrder(emptyList()) { it.id })
+    }
+
+    @Test
+    fun `ids the order does not name keep their relative order and land at the end`() {
+        assertEquals(
+            listOf("c", "a", "b"),
+            listOf(Row("a"), Row("b"), Row("c")).sortedByOrder(listOf("c")) { it.id }.map { it.id },
+        )
+    }
+
+    @Test
+    fun `an order naming ids that no longer exist still orders the ones that do`() {
+        assertEquals(
+            listOf("c", "a", "b"),
+            rows.sortedByOrder(listOf("gone", "c", "a", "also-gone", "b")) { it.id }.map { it.id },
+        )
+    }
+
+    @Test
+    fun `a duplicated id in the stored order neither drops nor duplicates a row`() {
+        val sorted = rows.sortedByOrder(listOf("c", "a", "c", "b")) { it.id }
+        assertEquals(rows.toSet(), sorted.toSet())
+        assertEquals(3, sorted.size)
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/share/SessionShareE2eTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/share/SessionShareE2eTest.kt
@@ -1,16 +1,14 @@
 package app.skerry.shared.share
 
 import app.skerry.server.config.ServerConfig
-import app.skerry.server.module
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.KtorSyncClient
 import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.startTestServer
 import app.skerry.shared.team.TeamRole
 import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.initializeVaultCrypto
-import io.ktor.server.engine.embeddedServer
-import io.ktor.server.netty.Netty
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -56,7 +54,7 @@ class SessionShareE2eTest {
                 "SKERRY_PORT" to "$port",
             ),
         )
-        val server = embeddedServer(Netty, port = port) { module(config) }.start(wait = false)
+        val server = startTestServer(config, port)
         val sync = KtorSyncClient("http://localhost:$port")
         val shares = KtorSessionShareClient("http://localhost:$port", KtorSyncClient.defaultHttpClient())
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -163,7 +161,7 @@ class SessionShareE2eTest {
                 "SKERRY_PORT" to "$port",
             ),
         )
-        val server = embeddedServer(Netty, port = port) { module(config) }.start(wait = false)
+        val server = startTestServer(config, port)
         val sync = KtorSyncClient("http://localhost:$port")
         val shares = KtorSessionShareClient("http://localhost:$port", KtorSyncClient.defaultHttpClient())
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/EmbeddedTestServer.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/EmbeddedTestServer.kt
@@ -1,0 +1,16 @@
+package app.skerry.shared.sync
+
+import app.skerry.server.config.ServerConfig
+import app.skerry.server.module
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+
+/**
+ * The real server, in-process, for the end-to-end tests.
+ *
+ * Bound to loopback on purpose: [ServerConfig] leaves registration open by default, and Ktor with no
+ * `host` binds every interface — so a `./gradlew allTests` on a laptop would publish an
+ * unauthenticated `POST /register` to whatever network it is on, for as long as the test runs.
+ */
+internal fun startTestServer(config: ServerConfig, port: Int) =
+    embeddedServer(Netty, host = "127.0.0.1", port = port) { module(config) }.start(wait = false)

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/ServerRecordTypeAllowListTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/ServerRecordTypeAllowListTest.kt
@@ -1,0 +1,81 @@
+package app.skerry.shared.sync
+
+import app.skerry.server.config.ServerConfig
+import app.skerry.shared.vault.RecordType
+import kotlinx.coroutines.runBlocking
+import java.net.ServerSocket
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * The server's allow-list of record types is a hand-written mirror of [RecordType] across a module
+ * boundary, and a type missing from it is not a loud failure: the push is refused with 400, which
+ * [SyncEngine] reads as `Kind.PROTOCOL` and — for an optional type — swallows as "this server is
+ * just older". The record then never leaves the device and nothing anywhere says so.
+ *
+ * So the correspondence is asserted against the real route rather than trusted: every type the
+ * client can sync must be accepted, and the one type that never syncs must still be refused, or the
+ * exclusion below is an accident rather than a decision.
+ */
+class ServerRecordTypeAllowListTest {
+
+    private val accountId = "types@example.com"
+
+    /**
+      * Derived, not restated: the client's own answer for what never leaves the device (today only
+      * TERMINAL_HISTORY — per-host, large, sensitive). Naming it here would make a second type added
+      * to [SyncSettings] fail this test against the server, which would be the wrong culprit.
+      */
+    private val neverSynced = RecordType.entries.filterNot { SyncSettings().shouldSync(it) }.toSet()
+
+    @Test
+    fun `the server accepts every record type the client can sync and refuses the one it cannot`() = runBlocking {
+        val port = ServerSocket(0).use { it.localPort }
+        val dbFile = Files.createTempFile("skerry-types-", ".db")
+        val config = ServerConfig.fromEnv(
+            mapOf(
+                "SKERRY_DB_URL" to "jdbc:sqlite:${dbFile.toAbsolutePath()}",
+                "SKERRY_JWT_SECRET" to "e2e-test-secret-not-default",
+                "SKERRY_PORT" to "$port",
+            ),
+        )
+        val server = startTestServer(config, port)
+        val client = KtorSyncClient("http://localhost:$port")
+        try {
+            val session = client.register(accountId, ByteArray(32) { 1 }, ByteArray(48), DeviceInfo("dev", "Laptop"))
+
+            // One batch, because the route validates every type before it applies any of them: a type
+            // missing from the allow-list refuses the whole push, and `push` throws right here. The
+            // echoed page is the weaker second half of the oracle — it catches a server that accepts
+            // a type and then drops it.
+            val synced = RecordType.entries.filter { it !in neverSynced }
+            val page = client.push(session, synced.map { record(it) })
+            assertEquals(synced.map { it.name }.toSet(), page.records.map { it.type }.toSet())
+
+            neverSynced.forEach { type ->
+                val refused = assertFailsWith<SyncException> { client.push(session, listOf(record(type))) }
+                assertEquals(
+                    SyncException.Kind.PROTOCOL,
+                    refused.kind,
+                    "$type is excluded from sync on the client, so the server must refuse it too",
+                )
+            }
+        } finally {
+            client.close()
+            server.stop(100, 100)
+            Files.deleteIfExists(dbFile)
+        }
+    }
+
+    private fun record(type: RecordType) = RemoteRecord(
+        id = "id-${type.name}",
+        type = type.name,
+        version = 1,
+        updatedAt = "2026-06-29T00:00:00Z",
+        deviceId = "dev",
+        deleted = false,
+        blob = "ciphertext".encodeToByteArray(),
+    )
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncE2eTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncE2eTest.kt
@@ -1,14 +1,11 @@
 package app.skerry.shared.sync
 
 import app.skerry.server.config.ServerConfig
-import app.skerry.server.module
 import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.initializeVaultCrypto
 import app.skerry.shared.vault.recordAad
-import io.ktor.server.engine.embeddedServer
-import io.ktor.server.netty.Netty
 import kotlinx.coroutines.runBlocking
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -44,7 +41,7 @@ class SyncE2eTest {
                 "SKERRY_PORT" to "$port",
             ),
         )
-        val server = embeddedServer(Netty, port = port) { module(config) }.start(wait = false)
+        val server = startTestServer(config, port)
         val client = KtorSyncClient("http://localhost:$port")
         val vaultDir = Files.createTempDirectory("skerry-e2e-vault")
         try {
@@ -118,7 +115,7 @@ class SyncE2eTest {
                 "SKERRY_PORT" to "$port",
             ),
         )
-        val server = embeddedServer(Netty, port = port) { module(config) }.start(wait = false)
+        val server = startTestServer(config, port)
         val client = KtorSyncClient("http://localhost:$port")
         val vaultDir = Files.createTempDirectory("skerry-e2e-vault")
         try {
@@ -173,7 +170,7 @@ class SyncE2eTest {
                 "SKERRY_PORT" to "$port",
             ),
         )
-        val server = embeddedServer(Netty, port = port) { module(config) }.start(wait = false)
+        val server = startTestServer(config, port)
         val client = KtorSyncClient("http://localhost:$port")
         try {
             val syncSalt = crypto.deriveSyncSalt(accountId)

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncEngineNewTypeBatchTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncEngineNewTypeBatchTest.kt
@@ -86,6 +86,32 @@ class SyncEngineNewTypeBatchTest {
         assertFalse(RecordType.TRUSTED_CA.name in pushedTypes, "the refused batch must not be recorded as pushed")
     }
 
+    /**
+     * The optional batch carries more than one type, and the server refuses a whole batch on the
+     * first type it can't name. So a deployment that predates only the newest of them must still
+     * receive the older ones — TEAM_PEER above all: it is the fingerprint every later seal is held
+     * to (#319), and a second device without it seals to whatever the server answers.
+     */
+    @Test
+    fun `one refused optional type does not silence the rest of that batch`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devD")
+        vault.create(password.toCharArray())
+        vault.put("h1", RecordType.HOST, "host".encodeToByteArray())
+        vault.put("ca1", RecordType.TRUSTED_CA, "ca".encodeToByteArray())
+        vault.put("p1", RecordType.TEAM_PEER, "pin".encodeToByteArray())
+        vault.put("skerry.library.order", RecordType.LIBRARY_ORDER, "order".encodeToByteArray())
+
+        val client = OldServer(RecordType.LIBRARY_ORDER)
+        SyncEngine(client, vault, InMemorySyncStateStore()).sync(session)
+
+        val pushedTypes = client.pushed.map { it.type }.toSet()
+        assertTrue(RecordType.HOST.name in pushedTypes)
+        assertTrue(RecordType.TRUSTED_CA.name in pushedTypes, "a CA must still reach a server that only lacks the order type")
+        assertTrue(RecordType.TEAM_PEER.name in pushedTypes, "a verified peer pin must still reach the account's other devices")
+        assertFalse(RecordType.LIBRARY_ORDER.name in pushedTypes, "the refused type must not be recorded as pushed")
+    }
+
     @Test
     fun `a server that knows the type receives it`() = runBlocking {
         initializeVaultCrypto()

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/WorkspaceSyncE2eTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/WorkspaceSyncE2eTest.kt
@@ -1,7 +1,6 @@
 package app.skerry.shared.sync
 
 import app.skerry.server.config.ServerConfig
-import app.skerry.server.module
 import app.skerry.shared.host.Host
 import app.skerry.shared.host.VaultHostStore
 import app.skerry.shared.snippet.Snippet
@@ -16,8 +15,6 @@ import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.WorkspaceLayout
 import app.skerry.shared.vault.WorkspaceLayoutStore
 import app.skerry.shared.vault.initializeVaultCrypto
-import io.ktor.server.engine.embeddedServer
-import io.ktor.server.netty.Netty
 import kotlinx.coroutines.runBlocking
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -36,11 +33,11 @@ class WorkspaceSyncE2eTest {
 
     private val accountId = "alice@example.com"
     private val masterPassword = "correct horse battery staple"
+    private val crypto = IonspinVaultCrypto()
 
     @Test
-    fun `device B sees hosts snippets and tunnels of device A in tree order`() = runBlocking {
+    fun `device B sees hosts snippets and tunnels of device A in tree and library order`() = runBlocking {
         initializeVaultCrypto()
-        val crypto = IonspinVaultCrypto()
         val port = ServerSocket(0).use { it.localPort }
         val dbFile = Files.createTempFile("skerry-ws-e2e-", ".db")
         val config = ServerConfig.fromEnv(
@@ -50,26 +47,13 @@ class WorkspaceSyncE2eTest {
                 "SKERRY_PORT" to "$port",
             ),
         )
-        val server = embeddedServer(Netty, port = port) { module(config) }.start(wait = false)
+        val server = startTestServer(config, port)
         val client = KtorSyncClient("http://localhost:$port")
         val dirA = Files.createTempDirectory("skerry-ws-a")
         val dirB = Files.createTempDirectory("skerry-ws-b")
         try {
-            // --- Device A: populate the workspace via vault stores ---
-            val vaultA = FileVault(dirA.resolve("vault.json").toString().toPath(), crypto, "devA", FileSystem.SYSTEM) { "2026-06-29T00:00:00Z" }
-            vaultA.create(masterPassword.toCharArray())
-            val hostsA = VaultHostStore(vaultA)
-            hostsA.put(Host("h1", "Web", "web.example.com", 22, "root", group = "prod"))
-            hostsA.put(Host("h2", "Db", "db.example.com", 22, "root", group = "prod"))
-            hostsA.put(Host("h3", "Bastion", "bastion.example.com", 22, "ubuntu"))
-            hostsA.reorder { it.reversed() } // tree order: h3, h2, h1
-            VaultSnippetStore(vaultA).put(Snippet("s1", "Disk", "df -h", tags = listOf("ops")))
-            VaultTunnelStore(vaultA).put(
-                Tunnel("t1", "DB tunnel", hostId = "h2", direction = TunnelDirection.Local, bindPort = 5432, destHost = "127.0.0.1", destPort = 5432),
-            )
-            VaultKnownHostsStore(vaultA).add(KnownHost("web.example.com", 22, "ssh-ed25519", "SHA256:AAA", "2026-06-29T00:00:00Z"))
-            // An empty folder (no hosts) lives in the layout record — it syncs too.
-            WorkspaceLayoutStore(vaultA).apply { write(read().copy(groups = listOf("staging"))) }
+            val vaultA = newVault(dirA, "devA")
+            populateWorkspace(vaultA)
 
             val syncSalt = crypto.deriveSyncSalt(accountId)
             val masterA = crypto.deriveMasterKey(masterPassword.toCharArray(), syncSalt)
@@ -81,7 +65,7 @@ class WorkspaceSyncE2eTest {
             val sessionB = client.login(accountId, crypto.deriveAuthKey(masterB), DeviceInfo("devB", "Phone B"))
             val dataKeyB = crypto.unwrapDataKey(masterB, client.fetchWrappedDataKey(sessionB))
                 ?: error("device B failed to unwrap dataKey")
-            val vaultB = FileVault(dirB.resolve("vault.json").toString().toPath(), crypto, "devB", FileSystem.SYSTEM) { "2026-06-29T00:00:00Z" }
+            val vaultB = newVault(dirB, "devB")
             vaultB.create(masterPassword.toCharArray())
             vaultB.unlockWithDataKey(dataKeyB) // same dataKey as A (as SyncCoordinator does)
             SyncEngine(client, vaultB).sync(sessionB)
@@ -91,8 +75,8 @@ class WorkspaceSyncE2eTest {
             assertEquals(listOf("h3", "h2", "h1"), hostsB.all().map { it.id })
             assertEquals("Web", hostsB.all().first { it.id == "h1" }.label)
             assertEquals("prod", hostsB.all().first { it.id == "h2" }.group)
-            assertEquals(listOf("s1"), VaultSnippetStore(vaultB).all().map { it.id })
-            assertEquals("df -h", VaultSnippetStore(vaultB).all().single().command)
+            assertEquals(listOf("s2", "s1"), VaultSnippetStore(vaultB).all().map { it.id })
+            assertEquals("df -h", VaultSnippetStore(vaultB).all().first { it.id == "s1" }.command)
             assertEquals(listOf("t1"), VaultTunnelStore(vaultB).all().map { it.id })
             assertEquals("h2", VaultTunnelStore(vaultB).all().single().hostId)
             assertEquals(listOf("web.example.com"), VaultKnownHostsStore(vaultB).all().map { it.host })
@@ -102,5 +86,30 @@ class WorkspaceSyncE2eTest {
             server.stop(100, 100)
             Files.deleteIfExists(dbFile)
         }
+    }
+
+    private fun newVault(dir: java.nio.file.Path, device: String) =
+        FileVault(dir.resolve("vault.json").toString().toPath(), crypto, device, FileSystem.SYSTEM) { "2026-06-29T00:00:00Z" }
+
+    /** Everything device A owns, in the order it must reach device B in. */
+    private fun populateWorkspace(vault: FileVault) {
+        vault.create(masterPassword.toCharArray())
+        val hosts = VaultHostStore(vault)
+        hosts.put(Host("h1", "Web", "web.example.com", 22, "root", group = "prod"))
+        hosts.put(Host("h2", "Db", "db.example.com", 22, "root", group = "prod"))
+        hosts.put(Host("h3", "Bastion", "bastion.example.com", 22, "ubuntu"))
+        hosts.reorder { it.reversed() } // tree order: h3, h2, h1
+        val snippets = VaultSnippetStore(vault)
+        snippets.put(Snippet("s1", "Disk", "df -h", tags = listOf("ops")))
+        snippets.put(Snippet("s2", "Load", "uptime"))
+        // Library order: s2, s1. It is a record of its own (LIBRARY_ORDER), so this also proves the
+        // server accepts the type and device B reads it back through a real merge.
+        snippets.reorder { it.reversed() }
+        VaultTunnelStore(vault).put(
+            Tunnel("t1", "DB tunnel", hostId = "h2", direction = TunnelDirection.Local, bindPort = 5432, destHost = "127.0.0.1", destPort = 5432),
+        )
+        VaultKnownHostsStore(vault).add(KnownHost("web.example.com", 22, "ssh-ed25519", "SHA256:AAA", "2026-06-29T00:00:00Z"))
+        // An empty folder (no hosts) lives in the layout record — it syncs too.
+        WorkspaceLayoutStore(vault).apply { write(read().copy(groups = listOf("staging"))) }
     }
 }


### PR DESCRIPTION
Store order in WorkspaceLayout (snippetOrder/runbookOrder fields), make reorder() abstract on SnippetStore/RunbookStore interfaces, implement atomic reorder in VaultSnippetStore/VaultRunbookStore with id-set validation, add migration seeding (first put() after upgrade seeds order from existing codec entries), only write changed records during reorder (no tombstone spam).

Addresses review feedback from #349:
- reorder() is now abstract (no non-atomic default implementation)
- Order is stored in WorkspaceLayout as before
- Migration seeding added: first put() after upgrade seeds order from existing entries

Part 1 of 3, extracted from #349.