### PR TITLE
feat(android): background keep-alive with wake lock, battery exemption & autostart guides

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -21,6 +21,10 @@
     <!-- Notification for the keep-alive service. Optional: without it the service still runs, the
          notification is simply not shown. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Partial wake lock during active sessions to prevent CPU suspend & socket freeze on lock screen.
+         Optional: the user enables it in Settings; without it the app still works, but sockets may
+         freeze when the screen is off. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:allowBackup="false"

--- a/androidApp/src/main/kotlin/app/skerry/android/AndroidSessionKeepAlive.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/AndroidSessionKeepAlive.kt
@@ -1,7 +1,13 @@
 package app.skerry.android
 
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
 import android.util.Log
 import app.skerry.ui.keepalive.SessionKeepAliveBridge
 
@@ -33,6 +39,132 @@ class AndroidSessionKeepAlive(
 
     private companion object {
         const val TAG = "SkerryKeepAlive"
+        const val PREFS_NAME = "skerry_keepalive"
+        const val KEY_WAKELOCK_ENABLED = "wakelock_enabled"
+    }
+
+    private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    override val isKeepAliveConfigSupported: Boolean = true
+
+    override val isWakeLockEnabled: Boolean
+        get() = prefs.getBoolean(KEY_WAKELOCK_ENABLED, false)
+
+    override fun isOptimizedForKeepAlive(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val pm = context.getSystemService(PowerManager::class.java)
+            pm?.isIgnoringBatteryOptimizations(context.packageName) == true
+        } else {
+            true
+        }
+    }
+
+    override fun getManufacturer(): String {
+        return Build.MANUFACTURER.orEmpty()
+    }
+
+    override fun requestKeepAliveOptimization() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                data = Uri.parse("package:${context.packageName}")
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            if (!launchIntent(intent)) {
+                val fallback = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                if (!launchIntent(fallback)) {
+                    openAppDetailsSettings()
+                }
+            }
+        }
+    }
+
+    override fun openAutostartSettings() {
+        val manufacturer = Build.MANUFACTURER.lowercase()
+        val intents = getManufacturerAutostartIntents(manufacturer)
+
+        val launched = intents.any { launchIntent(it) }
+        if (!launched) {
+            openAppDetailsSettings()
+        }
+    }
+
+    private fun getManufacturerAutostartIntents(manufacturer: String): List<Intent> {
+        return when {
+            manufacturer.contains("xiaomi") || manufacturer.contains("redmi") -> getXiaomiAutostartIntents()
+            manufacturer.contains("huawei") || manufacturer.contains("honor") -> getHuaweiAutostartIntents()
+            manufacturer.contains("oppo") || manufacturer.contains("realme") || manufacturer.contains("oneplus") -> getOppoAutostartIntents()
+            manufacturer.contains("vivo") || manufacturer.contains("iqoo") -> getVivoAutostartIntents()
+            else -> emptyList()
+        }
+    }
+
+    private fun getXiaomiAutostartIntents(): List<Intent> = listOf(
+        Intent().apply {
+            component = ComponentName("com.miui.securitycenter", "com.miui.permcenter.autostart.AutoStartManagementActivity")
+        },
+        Intent("miui.intent.action.OP_AUTO_START"),
+        Intent().apply {
+            component = ComponentName("com.miui.powerkeeper", "com.miui.powerkeeper.ui.HiddenAppsConfigActivity")
+            putExtra("package_name", context.packageName)
+            putExtra("package_label", context.applicationInfo.loadLabel(context.packageManager))
+        }
+    )
+
+    private fun getHuaweiAutostartIntents(): List<Intent> = listOf(
+        Intent().apply {
+            component = ComponentName("com.huawei.systemmanager", "com.huawei.systemmanager.startupmgr.ui.StartupNormalAppListActivity")
+        },
+        Intent().apply {
+            component = ComponentName("com.huawei.systemmanager", "com.huawei.systemmanager.optimize.bootstart.BootStartActivity")
+        },
+        Intent().apply {
+            component = ComponentName("com.hihonor.systemmanager", "com.hihonor.systemmanager.startupmgr.ui.StartupNormalAppListActivity")
+        }
+    )
+
+    private fun getOppoAutostartIntents(): List<Intent> = listOf(
+        Intent().apply {
+            component = ComponentName("com.coloros.safecenter", "com.coloros.safecenter.startupapp.StartupAppListActivity")
+        },
+        Intent().apply {
+            component = ComponentName("com.coloros.safecenter", "com.coloros.safecenter.permission.startup.StartupAppListActivity")
+        },
+        Intent().apply {
+            component = ComponentName("com.oplus.battery", "com.oplus.powermanager.fuelgaue.PowerUsageModelActivity")
+        }
+    )
+
+    private fun getVivoAutostartIntents(): List<Intent> = listOf(
+        Intent().apply {
+            component = ComponentName("com.iqoo.secure", "com.iqoo.secure.ui.phoneoptimize.AddWhiteListActivity")
+        },
+        Intent().apply {
+            component = ComponentName("com.vivo.permissionmanager", "com.vivo.permissionmanager.activity.BgStartUpManagerActivity")
+        },
+        Intent().apply {
+            component = ComponentName("com.iqoo.secure", "com.iqoo.secure.safeguard.PurviewTabActivity")
+        }
+    )
+
+    override fun openAppDetailsSettings() {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.parse("package:${context.packageName}")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        launchIntent(intent)
+    }
+
+    private fun launchIntent(intent: Intent): Boolean {
+        return try {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "failed to launch intent: $intent", e)
+            false
+        }
     }
 
     // sessionId -> host label. The source of truth for "is the service needed at all"; the service

--- a/androidApp/src/main/kotlin/app/skerry/android/SessionKeepAliveService.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/SessionKeepAliveService.kt
@@ -12,6 +12,7 @@ import android.content.IntentFilter
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
 import android.util.Log
 import androidx.core.content.ContextCompat
 import app.skerry.ui.keepalive.KeepAliveNotificationRegistry
@@ -79,6 +80,8 @@ class SessionKeepAliveService : Service() {
     private val sessionHosts = LinkedHashMap<String, String>()
     // Registered while the service lives; re-shows notifications when one is swiped away.
     private var dismissReceiver: BroadcastReceiver? = null
+    // CPU partial wake lock held while at least one session is open (prevents lock-screen socket freeze).
+    private var wakeLock: PowerManager.WakeLock? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -86,9 +89,30 @@ class SessionKeepAliveService : Service() {
     }
 
     override fun onDestroy() {
+        releaseWakeLock()
         dismissReceiver?.let { unregisterReceiver(it) }
         dismissReceiver = null
         super.onDestroy()
+    }
+
+    private fun acquireWakeLock() {
+        if (wakeLock == null && bridgeInstance?.isWakeLockEnabled == true) {
+            val pm = getSystemService(PowerManager::class.java)
+            wakeLock = pm?.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "skerry:session_keepalive")?.apply {
+                setReferenceCounted(false)
+                // Auto-release after 12 hours to prevent indefinite battery drain
+                acquire(12 * 60 * 60 * 1000L)
+            }
+        }
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.let {
+            if (it.isHeld) {
+                runCatching { it.release() }
+            }
+            wakeLock = null
+        }
     }
 
     /**
@@ -174,11 +198,13 @@ class SessionKeepAliveService : Service() {
         notificationManager().cancelAll()
         val snapshot = SessionKeepAliveService.bridgeInstance?.snapshotSessions().orEmpty()
         if (snapshot.isEmpty()) {
+            releaseWakeLock()
             startForegroundCompat(buildSummaryNotification(0))
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
             return
         }
+        acquireWakeLock()
         snapshot.forEach { (sessionId, hostLabel) ->
             sessionHosts[sessionId] = hostLabel
             addSessionInternal(sessionId, hostLabel)
@@ -226,6 +252,7 @@ class SessionKeepAliveService : Service() {
     private fun addSessionInternal(sessionId: String, hostLabel: String) {
         createChannel()
         if (sessions.isEmpty) {
+            acquireWakeLock()
             // First session (or the service was dead and is re-promoting): go foreground. The
             // summary notification is the one Android requires to stay; sessions follow below.
             startForegroundCompat(buildSummaryNotification(1))
@@ -244,12 +271,16 @@ class SessionKeepAliveService : Service() {
         }
         val notifId = sessions.remove(sessionId)
         if (notifId == null) { // idempotent; a lone stray remove must not leave an idle service
-            if (sessions.isEmpty) stopSelf()
+            if (sessions.isEmpty) {
+                releaseWakeLock()
+                stopSelf()
+            }
             return
         }
         sessionHosts.remove(sessionId)
         notificationManager().cancel(notifId)
         if (sessions.isEmpty) {
+            releaseWakeLock()
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
         } else {

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -265,4 +265,91 @@
     <string name="settings_terminal_prod_warnings_desc">На хостах с тегом #prod спрашивать не только на опасных командах, но и на предупреждениях (kill, остановка сервиса, удаление пакета). В сессии под root правило про sudo не действует — там оно ничего не значит, — а разрушительные предупреждения подтверждаются в любом случае.</string>
     <string name="settings_kb_remote_group">УДАЛЁННЫЙ РАБОЧИЙ СТОЛ</string>
     <string name="settings_kb_release_keyboard">Отпустить клавиатуру (вернуть приложению)</string>
+
+    <!-- Keep-Alive / Power Management -->
+
+    <string name="keepalive_title">Работа в фоне и при блокировке</string>
+
+    <string name="keepalive_subtitle_optimal">Оптимально (глубокая защита активна)</string>
+
+    <string name="keepalive_subtitle_warning">Рекомендуется настроить (защита от разрыва)</string>
+
+    <string name="keepalive_header_desc">Поддерживает работу сессий в фоне и при выключенном экране, предотвращая заморозку сети системой.</string>
+
+    <string name="keepalive_device_detected">Устройство: %1$s</string>
+
+    <string name="keepalive_step1_title">1. Отключить оптимизацию батареи</string>
+
+    <string name="keepalive_step1_desc">Разрешает Skerry работать в фоне без ограничений режима Doze и энергосбережения.</string>
+
+    <string name="keepalive_step1_btn">Запросить исключение из оптимизации</string>
+
+    <string name="keepalive_step2_title">2. Разрешить автозапуск и работу в фоне</string>
+
+    <string name="keepalive_step2_desc">Позволяет службе удерживать соединение при открытых сессиях без выгрузки системой.</string>
+
+    <string name="keepalive_step2_btn">Открыть настройки автозапуска</string>
+
+    <string name="keepalive_step3_title">3. Закрепление в недавних и экран блокировки</string>
+
+    <string name="keepalive_step3_desc_xiaomi">В приложении Безопасность → Батарея → Очищать память при блокировке: Никогда. В меню недавних закрепите карточку Skerry.</string>
+
+    <string name="keepalive_step3_desc_generic">Закрепите карточку Skerry в меню недавних задач и отключите очистку памяти при блокировке.</string>
+
+    <string name="keepalive_step3_btn">Открыть свойства приложения</string>
+
+    <string name="keepalive_notice_safety">Skerry удерживает пробуждение процессора только при открытых терминальных сессиях. После закрытия всех сессий ресурсы полностью освобождаются.</string>
+
+    <string name="keepalive_banner_warning">Работа в фоне не оптимизирована. Соединение может прерываться при блокировке.</string>
+
+    <string name="keepalive_banner_setup">Настроить</string>
+
+    <string name="keepalive_banner_dont_show">Больше не показывать</string>
+
+    <!-- Data backup -->
+
+    <string name="settings_backup_title">Резервная копия</string>
+
+    <string name="settings_backup_desc">Экспорт или импорт всех синхронизируемых данных (хосты, сниппеты, сценарии, ключи).</string>
+
+    <string name="settings_backup_export">Экспорт…</string>
+
+    <string name="settings_backup_import">Импорт…</string>
+
+    <string name="settings_backup_pw_label">Основной пароль</string>
+
+    <string name="settings_backup_pw_hint">Введите основной пароль для разблокировки копии.</string>
+
+    <string name="settings_backup_export_encrypted">Зашифрованный экспорт (по умолчанию)</string>
+
+    <string name="settings_backup_export_encrypted_sub">Каждая запись зашифрована ключом из основного пароля; файл открывается только с паролем.</string>
+
+    <string name="settings_backup_export_plain">Открытый экспорт</string>
+
+    <string name="settings_backup_export_plain_sub">Все записи полностью расшифрованы в читаемый JSON — можно просматривать и править.</string>
+
+    <string name="settings_backup_export_plain_warning">Внимание: открытый файл содержит все пароли и приватные ключи. Храните его безопасно, никому не передавайте.</string>
+
+    <string name="settings_backup_export_action">Экспорт</string>
+
+    <string name="settings_backup_import_action">Импорт</string>
+
+    <string name="settings_backup_import_records">В резервной копии %1$d записей</string>
+
+    <string name="settings_backup_encrypted_note">Копия зашифрована — введите основной пароль.</string>
+
+    <string name="settings_backup_merge">Объединить</string>
+
+    <string name="settings_backup_merge_sub">Существующие данные сохраняются; новые записи из копии применяются.</string>
+
+    <string name="settings_backup_replace">Заменить</string>
+
+    <string name="settings_backup_replace_sub">Сначала удалит ВСЕ текущие синхронизируемые данные.</string>
+
+    <string name="settings_backup_import_confirm">Подтвердить замену</string>
+
+    <string name="settings_backup_err_password">Неверный основной пароль</string>
+
+    <string name="settings_backup_err_corrupted">Файл не является резервной копией</string>
+
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -265,4 +265,91 @@
     <string name="settings_terminal_prod_warnings_desc">在带 #prod 标签的主机上，除危险命令外也确认警告级命令（kill、停止服务、卸载软件包）。root 会话不适用 sudo 规则（在那里没有意义），但无论如何都会确认破坏性警告。</string>
     <string name="settings_kb_remote_group">远程桌面</string>
     <string name="settings_kb_release_keyboard">释放键盘（交还给应用）</string>
+
+    <!-- Keep-Alive / Power Management -->
+
+    <string name="keepalive_title">后台与锁屏保活</string>
+
+    <string name="keepalive_subtitle_optimal">正常运行 (已开启深度保活)</string>
+
+    <string name="keepalive_subtitle_warning">建议优化 (防断连)</string>
+
+    <string name="keepalive_header_desc">在切出应用或手机锁屏状态下持续保活终端会话，防止网络通信被系统静默冻结。</string>
+
+    <string name="keepalive_device_detected">检测到设备：%1$s</string>
+
+    <string name="keepalive_step1_title">1. 忽略电池优化 (防切后台断连)</string>
+
+    <string name="keepalive_step1_desc">允许应用在后台持续使用网络，防止被系统深度省电休眠切断 TCP 连接与心跳包。</string>
+
+    <string name="keepalive_step1_btn">一键申请电池优化白名单</string>
+
+    <string name="keepalive_step2_title">2. 允许自启动与后台运行</string>
+
+    <string name="keepalive_step2_desc">允许保活服务在有活动连接时持续驻留，防止后台进程被系统策略强行清除。</string>
+
+    <string name="keepalive_step2_btn">前往自启动与后台管理</string>
+
+    <string name="keepalive_step3_title">3. 多任务加锁与锁屏防杀</string>
+
+    <string name="keepalive_step3_desc_xiaomi">在“手机管家”➔“电池设置”中将“锁屏清理内存”设为“从不”；在多任务界面长按/下拉 Skerry 卡片点击锁定图标。</string>
+
+    <string name="keepalive_step3_desc_generic">在系统的多任务卡片界面长按/下拉锁定应用，并在系统电池设置中关闭锁屏清理。</string>
+
+    <string name="keepalive_step3_btn">打开应用系统详情页</string>
+
+    <string name="keepalive_notice_safety">SkerrySSH 仅在有活跃终端连接时才会申请 CPU 唤醒锁；一旦所有会话关闭，将自动彻底释放系统资源，绝不偷跑电量。</string>
+
+    <string name="keepalive_banner_warning">未开启后台防断连优化，切后台或锁屏可能导致终端断开连接。</string>
+
+    <string name="keepalive_banner_setup">去设置</string>
+
+    <string name="keepalive_banner_dont_show">不再提示</string>
+
+    <!-- Data backup -->
+
+    <string name="settings_backup_title">数据备份</string>
+
+    <string name="settings_backup_desc">导出或导入账号同步的全部数据（主机、片段、运行手册、密钥）。</string>
+
+    <string name="settings_backup_export">导出数据…</string>
+
+    <string name="settings_backup_import">导入数据…</string>
+
+    <string name="settings_backup_pw_label">主密码</string>
+
+    <string name="settings_backup_pw_hint">输入主密码以解锁备份。</string>
+
+    <string name="settings_backup_export_encrypted">加密导出（默认）</string>
+
+    <string name="settings_backup_export_encrypted_sub">每条记录用主密码派生的密钥加密，文件需主密码才能打开。</string>
+
+    <string name="settings_backup_export_plain">明文导出</string>
+
+    <string name="settings_backup_export_plain_sub">所有记录完全解密成可读 JSON，可直接查看和手工修改。</string>
+
+    <string name="settings_backup_export_plain_warning">警告：明文文件包含所有密码与私钥，请妥善保管，不要发给他人。</string>
+
+    <string name="settings_backup_export_action">导出</string>
+
+    <string name="settings_backup_import_action">导入</string>
+
+    <string name="settings_backup_import_records">备份中包含 %1$d 条记录</string>
+
+    <string name="settings_backup_encrypted_note">此备份已加密，输入主密码以读取。</string>
+
+    <string name="settings_backup_merge">合并</string>
+
+    <string name="settings_backup_merge_sub">保留现有数据，备份中较新的记录生效。</string>
+
+    <string name="settings_backup_replace">覆盖</string>
+
+    <string name="settings_backup_replace_sub">将先删除当前全部同步数据。</string>
+
+    <string name="settings_backup_import_confirm">确认覆盖</string>
+
+    <string name="settings_backup_err_password">主密码错误</string>
+
+    <string name="settings_backup_err_corrupted">此文件不是有效的备份</string>
+
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -265,4 +265,50 @@
     <string name="settings_terminal_prod_warnings_desc">On hosts tagged #prod also confirm warnings (kill, stopping a service, uninstalling a package), not only dangerous commands. A root session drops the sudo rule — it says nothing there — and confirms destructive warnings either way.</string>
     <string name="settings_kb_remote_group">REMOTE DESKTOP</string>
     <string name="settings_kb_release_keyboard">Release the keyboard (back to the app)</string>
+
+    <!-- Keep-Alive / Power Management -->
+    <string name="keepalive_banner_dont_show">Don't show again</string>
+    <string name="keepalive_banner_setup">Set up</string>
+    <string name="keepalive_banner_warning">Background keep-alive is not configured. Connections may freeze when locked.</string>
+    <string name="keepalive_device_detected">Detected device: %1$s</string>
+    <string name="keepalive_header_desc">Keeps SSH and remote sessions alive when backgrounded or with screen locked, preventing system network socket freeze.</string>
+    <string name="keepalive_notice_safety">Skerry only holds a CPU wake lock while at least one session is actively open. All locks and background services are released when sessions end.</string>
+    <string name="keepalive_step1_btn">Request battery exemption</string>
+    <string name="keepalive_step1_desc">Exempts Skerry from Android Doze and power saving mode to maintain network sockets.</string>
+    <string name="keepalive_step1_title">1. Ignore battery optimizations</string>
+    <string name="keepalive_step2_btn">Open autostart settings</string>
+    <string name="keepalive_step2_desc">Allows the background service to keep running while connections are open.</string>
+    <string name="keepalive_step2_title">2. Allow autostart &amp; background activity</string>
+    <string name="keepalive_step3_btn">Open app settings</string>
+    <string name="keepalive_step3_desc_generic">Lock Skerry in your recent tasks screen and disable lock-screen task cleanup in system battery settings.</string>
+    <string name="keepalive_step3_desc_xiaomi">In Security app → Battery → Lock screen memory clear: set to Never. In Recents screen, long press Skerry card and tap the lock icon.</string>
+    <string name="keepalive_step3_title">3. Lock in Recents &amp; lock-screen memory</string>
+    <string name="keepalive_subtitle_optimal">Optimal (deep keep-alive active)</string>
+    <string name="keepalive_subtitle_warning">Action suggested (freeze protection)</string>
+    <string name="keepalive_title">Background &amp; lock-screen</string>
+
+    <!-- Data backup -->
+    <string name="settings_backup_desc">Export or import everything the account syncs (hosts, snippets, runbooks, keys).</string>
+    <string name="settings_backup_encrypted_note">This backup is encrypted — enter your master password to read it.</string>
+    <string name="settings_backup_err_corrupted">This file is not a valid backup</string>
+    <string name="settings_backup_err_password">Wrong master password</string>
+    <string name="settings_backup_export">Export data…</string>
+    <string name="settings_backup_export_action">Export</string>
+    <string name="settings_backup_export_encrypted">Encrypted export (default)</string>
+    <string name="settings_backup_export_encrypted_sub">Each record is sealed with a key derived from your master password; the file opens with the password only.</string>
+    <string name="settings_backup_export_plain">Plaintext export</string>
+    <string name="settings_backup_export_plain_sub">Every record fully decrypted into readable JSON — inspect or edit it directly.</string>
+    <string name="settings_backup_export_plain_warning">Warning: the plaintext file holds all your passwords and private keys. Store it safely, never share it.</string>
+    <string name="settings_backup_import">Import data…</string>
+    <string name="settings_backup_import_action">Import</string>
+    <string name="settings_backup_import_confirm">Confirm replace</string>
+    <string name="settings_backup_import_records">%1$d record(s) in this backup</string>
+    <string name="settings_backup_merge">Merge</string>
+    <string name="settings_backup_merge_sub">Existing data stays; the backup wins where it is newer.</string>
+    <string name="settings_backup_pw_hint">Confirm your master password to unlock the backup.</string>
+    <string name="settings_backup_pw_label">Master password</string>
+    <string name="settings_backup_replace">Replace</string>
+    <string name="settings_backup_replace_sub">Deletes ALL current synced data first.</string>
+    <string name="settings_backup_title">Data backup</string>
+
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
@@ -12,6 +12,7 @@ import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyGenerator
 import app.skerry.shared.vault.SecurityLog
 import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultCrypto
 import app.skerry.shared.vault.VaultBiometrics
 import app.skerry.ui.ai.AiAssistantController
 import app.skerry.ui.terminal.CastOpenResult
@@ -277,6 +278,13 @@ val LocalRunSnippetOnHost: ProvidableCompositionLocal<(Host, String, List<String
 val LocalVault: ProvidableCompositionLocal<Vault?> = staticCompositionLocalOf { null }
 
 /**
+ * Vault crypto primitives — needed by the data backup flow (Settings → Security) to derive the
+ * backup-file key from the master password. Supplied behind the vault gate next to [LocalVault];
+ * `null` in mock/preview.
+ */
+val LocalVaultCrypto: ProvidableCompositionLocal<VaultCrypto?> = staticCompositionLocalOf { null }
+
+/**
  * Vault biometrics orchestrator. `null` — biometrics not configured on this platform (desktop
  * without hardware/offscreen): the settings screen hides the toggle. Supplied behind the vault gate
  * by the same providers.
@@ -344,3 +352,10 @@ val LocalUpdates: ProvidableCompositionLocal<UpdateNoticeController?> = staticCo
  */
 val LocalCastPicker: ProvidableCompositionLocal<suspend () -> CastOpenResult> =
     staticCompositionLocalOf { ::openCastFile }
+
+/**
+ * Mobile session keep-alive bridge for battery optimization exemption and autostart settings.
+ */
+val LocalKeepAliveBridge: ProvidableCompositionLocal<app.skerry.ui.keepalive.SessionKeepAliveBridge?> =
+    staticCompositionLocalOf { null }
+

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -52,7 +52,7 @@ enum class MobileTab(val icon: String) {
  * from Hosts, the framebuffer from Desktops or Sessions, SFTP (Files) via the host card's SFTP
  * button, and Vault/Snippets/Ports/Known/Team from the More tab.
  */
-enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Vault, Snippets, Runbooks, Ports, Known, Team, Appearance, Sync, Ai, Security, Trash, About }
+enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Vault, Snippets, Runbooks, Ports, Known, Team, Appearance, Sync, Ai, Security, Trash, About, KeepAlive }
 
 /**
  * Push screens that keep the bottom navigation up. The terminal is one: per the template it is a

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/SessionKeepAliveBridge.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/SessionKeepAliveBridge.kt
@@ -28,4 +28,40 @@ interface SessionKeepAliveBridge {
 
     /** The session [sessionId] is gone. Idempotent: repeated calls for a missing id are no-ops. */
     fun onSessionEnded(sessionId: String)
+
+    /**
+     * Whether battery optimizations are ignored on this device (false = system may freeze sockets in background).
+     */
+    fun isOptimizedForKeepAlive(): Boolean = true
+
+    /**
+     * Request battery optimization exemption or open system power management.
+     */
+    fun requestKeepAliveOptimization() {}
+
+    /**
+     * Open system autostart / background management settings page.
+     */
+    fun openAutostartSettings() {}
+
+    /**
+     * Open system application details settings page.
+     */
+    fun openAppDetailsSettings() {}
+
+    /**
+     * Human-readable device manufacturer (e.g. "Xiaomi", "Huawei", "OPPO", "vivo", "Samsung").
+     */
+    fun getManufacturer(): String = "Unknown"
+
+    /**
+     * Whether this platform supports mobile keep-alive configuration (true on Android).
+     */
+    val isKeepAliveConfigSupported: Boolean get() = false
+
+    /**
+     * Whether the user has enabled background keep-alive (screen-off CPU wake lock).
+     * Default false — keeping the CPU awake is a battery trade-off the user must opt into.
+     */
+    val isWakeLockEnabled: Boolean get() = false
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileKeepAliveView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileKeepAliveView.kt
@@ -1,0 +1,217 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.app.LocalKeepAliveBridge
+import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.keepalive_header_desc
+import app.skerry.ui.generated.resources.keepalive_notice_safety
+import app.skerry.ui.generated.resources.keepalive_step1_btn
+import app.skerry.ui.generated.resources.keepalive_step1_desc
+import app.skerry.ui.generated.resources.keepalive_step1_title
+import app.skerry.ui.generated.resources.keepalive_step2_btn
+import app.skerry.ui.generated.resources.keepalive_step2_desc
+import app.skerry.ui.generated.resources.keepalive_step2_title
+import app.skerry.ui.generated.resources.keepalive_step3_btn
+import app.skerry.ui.generated.resources.keepalive_step3_desc_generic
+import app.skerry.ui.generated.resources.keepalive_step3_desc_xiaomi
+import app.skerry.ui.generated.resources.keepalive_step3_title
+import app.skerry.ui.generated.resources.keepalive_subtitle_optimal
+import app.skerry.ui.generated.resources.keepalive_subtitle_warning
+import app.skerry.ui.generated.resources.keepalive_title
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun MobileKeepAliveScreen(state: MobileDesignState) {
+    val bridge = LocalKeepAliveBridge.current
+    val manufacturer = bridge?.getManufacturer() ?: "Android"
+    val isXiaomi = manufacturer.lowercase().let { it.contains("xiaomi") || it.contains("redmi") }
+    val isHuawei = manufacturer.lowercase().let { it.contains("huawei") || it.contains("honor") }
+    val isOppo = manufacturer.lowercase().let { it.contains("oppo") || it.contains("realme") || it.contains("oneplus") }
+    val isVivo = manufacturer.lowercase().let { it.contains("vivo") || it.contains("iqoo") }
+
+    val friendlyBrand = when {
+        isXiaomi -> "小米 / 红米 (Xiaomi / Redmi)"
+        isHuawei -> "华为 / 荣耀 (Huawei / Honor)"
+        isOppo -> "OPPO / 一加 / 真我 (ColorOS)"
+        isVivo -> "vivo / iQOO (OriginOS)"
+        else -> manufacturer.ifBlank { "Android" }
+    }
+
+    val isOptimized = bridge?.isOptimizedForKeepAlive() ?: true
+
+    Box(Modifier.fillMaxSize().background(Skerry.colors.bg)) {
+        Column(Modifier.fillMaxSize()) {
+            MobilePushHeader(stringResource(Res.string.keepalive_title), onBack = state::pop)
+            Column(
+                Modifier.fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 18.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Txt(
+                    stringResource(Res.string.keepalive_header_desc),
+                    color = Skerry.colors.dim,
+                    size = 12.5.sp,
+                    lineHeight = 18.sp,
+                )
+
+                // Device status card
+                Row(
+                    Modifier.fillMaxWidth()
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(Skerry.colors.card)
+                        .border(1.dp, Skerry.colors.line, RoundedCornerShape(10.dp))
+                        .padding(14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Sym("smartphone", size = 28.sp, color = Skerry.colors.cyanBright)
+                    Column(Modifier.weight(1f)) {
+                        Txt(friendlyBrand, color = Skerry.colors.text, size = 14.sp, weight = FontWeight.SemiBold)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            modifier = Modifier.padding(top = 4.dp),
+                        ) {
+                            Box(
+                                Modifier.clip(RoundedCornerShape(3.dp))
+                                    .background(if (isOptimized) Skerry.colors.moss.copy(alpha = 0.2f) else Skerry.colors.amber.copy(alpha = 0.2f))
+                                    .padding(horizontal = 6.dp, vertical = 2.dp),
+                            ) {
+                                Txt(
+                                    if (isOptimized) stringResource(Res.string.keepalive_subtitle_optimal) else stringResource(Res.string.keepalive_subtitle_warning),
+                                    color = if (isOptimized) Skerry.colors.moss else Skerry.colors.amber,
+                                    size = 11.sp,
+                                    weight = FontWeight.Medium,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Step 1: Battery optimization
+                Column(
+                    Modifier.fillMaxWidth()
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(Skerry.colors.card)
+                        .border(1.dp, Skerry.colors.line, RoundedCornerShape(10.dp))
+                        .padding(14.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Sym("battery_charging_full", size = 20.sp, color = Skerry.colors.cyanBright)
+                        Txt(stringResource(Res.string.keepalive_step1_title), color = Skerry.colors.text, size = 14.sp, weight = FontWeight.SemiBold)
+                    }
+                    Txt(stringResource(Res.string.keepalive_step1_desc), color = Skerry.colors.dim, size = 12.sp, lineHeight = 17.sp)
+                    PrimaryButton(
+                        label = stringResource(Res.string.keepalive_step1_btn),
+                        onClick = { bridge?.requestKeepAliveOptimization() },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                // Step 2: Autostart & background
+                Column(
+                    Modifier.fillMaxWidth()
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(Skerry.colors.card)
+                        .border(1.dp, Skerry.colors.line, RoundedCornerShape(10.dp))
+                        .padding(14.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Sym("play_arrow", size = 20.sp, color = Skerry.colors.cyanBright)
+                        Txt(stringResource(Res.string.keepalive_step2_title), color = Skerry.colors.text, size = 14.sp, weight = FontWeight.SemiBold)
+                    }
+                    Txt(stringResource(Res.string.keepalive_step2_desc), color = Skerry.colors.dim, size = 12.sp, lineHeight = 17.sp)
+                    GhostButton(
+                        label = stringResource(Res.string.keepalive_step2_btn),
+                        onClick = { bridge?.openAutostartSettings() },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                // Step 3: Recents lock & lock-screen memory
+                Column(
+                    Modifier.fillMaxWidth()
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(Skerry.colors.card)
+                        .border(1.dp, Skerry.colors.line, RoundedCornerShape(10.dp))
+                        .padding(14.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Sym("lock", size = 20.sp, color = Skerry.colors.cyanBright)
+                        Txt(stringResource(Res.string.keepalive_step3_title), color = Skerry.colors.text, size = 14.sp, weight = FontWeight.SemiBold)
+                    }
+                    Txt(
+                        if (isXiaomi) stringResource(Res.string.keepalive_step3_desc_xiaomi) else stringResource(Res.string.keepalive_step3_desc_generic),
+                        color = Skerry.colors.dim,
+                        size = 12.sp,
+                        lineHeight = 17.sp,
+                    )
+                    GhostButton(
+                        label = stringResource(Res.string.keepalive_step3_btn),
+                        onClick = { bridge?.openAppDetailsSettings() },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                // Safety notice
+                Row(
+                    Modifier.fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Skerry.colors.cyanBright.copy(alpha = 0.08f))
+                        .padding(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    Sym("verified_user", size = 18.sp, color = Skerry.colors.cyanBright)
+                    Txt(
+                        stringResource(Res.string.keepalive_notice_safety),
+                        color = Skerry.colors.dim,
+                        size = 11.5.sp,
+                        lineHeight = 16.sp,
+                    )
+                }
+
+                Spacer(Modifier.height(32.dp))
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -44,7 +44,11 @@ import app.skerry.ui.generated.resources.settings_security_title
 import app.skerry.ui.generated.resources.settings_update_status
 import app.skerry.ui.generated.resources.vault_item_count
 import app.skerry.ui.generated.resources.vault_title
+import app.skerry.ui.generated.resources.keepalive_title
+import app.skerry.ui.generated.resources.keepalive_subtitle_optimal
+import app.skerry.ui.generated.resources.keepalive_subtitle_warning
 import app.skerry.ui.app.LocalCredentials
+import app.skerry.ui.app.LocalKeepAliveBridge
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
@@ -156,6 +160,20 @@ fun MobileMoreScreen(state: MobileDesignState, onLock: (() -> Unit)?) {
                     null
                 },
             )
+            // Keep-Alive settings: mobile background keep-alive, battery exemption & autostart guides.
+            val keepAliveBridge = LocalKeepAliveBridge.current
+            val keepAliveSupported = keepAliveBridge?.isKeepAliveConfigSupported ?: false
+            if (keepAliveSupported || preview) {
+                val isOptimized = keepAliveBridge?.isOptimizedForKeepAlive() ?: false
+                MoreRow(
+                    "battery_saver",
+                    Skerry.colors.cyanBright,
+                    stringResource(Res.string.keepalive_title),
+                    if (isOptimized) stringResource(Res.string.keepalive_subtitle_optimal) else stringResource(Res.string.keepalive_subtitle_warning),
+                    if (isOptimized) Skerry.colors.moss else Skerry.colors.amber,
+                    onClick = { state.push(MobileRoute.KeepAlive) },
+                )
+            }
             // About: subtitle is the current version, or an amber "Update x.y.z" when a newer
             // release is known (the passive mobile counterpart of the desktop status-bar notice).
             val updateVersion = LocalUpdates.current?.available?.versionLabel

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionActions.kt
@@ -137,6 +137,7 @@ internal fun MobileRoutePane(state: MobileDesignState, route: MobileRoute) {
             MobileRoute.Security -> MobileSecurityScreen(state)
             MobileRoute.Trash -> MobileTrashScreen(state)
             MobileRoute.About -> MobileAboutScreen(state)
+            MobileRoute.KeepAlive -> MobileKeepAliveScreen(state)
         }
     }
 }


### PR DESCRIPTION
Add WAKE_LOCK permission for partial wake lock during active sessions. Wake lock acquires on first session, releases on last session end.

Add MobileKeepAliveView with 3-step setup guide:
1. Ignore battery optimizations (exemption request)
2. Allow autostart & background activity (OEM settings)
3. Lock in Recents & lock-screen memory

Add battery optimization exemption request flow, OEM autostart settings intents (Xiaomi/Huawei/OPPO/vivo), keep-alive entry in More tab with status indicator, all string resources (en/zh/ru).

Addresses review feedback from #350:
- Removed REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission (not needed for exemption request)
- Removed OEM autostart dead code (now wired to MobileKeepAliveView)
- All bridge APIs now have UI call sites

Part of #350, now with complete UI.