### PR TITLE
Offer the saved SSH password at a sudo prompt

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -270,6 +270,8 @@ class MainActivity : FragmentActivity() {
                     onTerminalFontSizeChange = { writeTerminalFontSize(dir, it) },
                     initialAllowServerClipboardWrite = readClipboardWrite(dir),
                     onAllowServerClipboardWriteChange = { writeClipboardWrite(dir, it) },
+                    initialOfferSudoPassword = readOfferSudoPassword(dir),
+                    onOfferSudoPasswordChange = { writeOfferSudoPassword(dir, it) },
                     initialReportTeamSessions = readReportTeamSessions(dir),
                     onReportTeamSessionsChange = { writeReportTeamSessions(dir, it) },
                     initialTerminalAutoFit = readTerminalAutoFit(dir),
@@ -322,11 +324,13 @@ class MainActivity : FragmentActivity() {
                         designState.terminalScrollback,
                         designState.terminalCursorStyle,
                         designState.allowServerClipboardWrite,
+                        designState.offerSudoPassword,
                     ) {
                         KeepAliveRuntime.terminalPrefs = app.skerry.ui.terminal.TerminalSessionPrefs(
                             designState.terminalScrollback,
                             designState.terminalCursorStyle,
                             clipboardWriteEnabled = designState.allowServerClipboardWrite,
+                            sudoPasswordEnabled = designState.offerSudoPassword,
                         )
                     }
                     // A per-session notification tap: activate the tapped terminal AND navigate to
@@ -426,6 +430,20 @@ class MainActivity : FragmentActivity() {
     private fun writeClipboardWrite(dir: File, enabled: Boolean) {
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "terminal_clipboard_write").writeText(enabled.toString()) }
+        }
+    }
+
+    /**
+     * Offering the saved password at a sudo prompt (More → Appearance → Terminal): "true"/"false"
+     * in `terminal_sudo_password`. Missing/unreadable → false (off by default, issue #360).
+     */
+    private fun readOfferSudoPassword(dir: File): Boolean = runCatching {
+        File(dir, "terminal_sudo_password").readText().trim().toBoolean()
+    }.getOrDefault(false)
+
+    private fun writeOfferSudoPassword(dir: File, enabled: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "terminal_sudo_password").writeText(enabled.toString()) }
         }
     }
 

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -115,6 +115,8 @@
     <string name="settings_terminal_host_connect_single">Одинарный клик</string>
     <string name="settings_terminal_host_connect_double">Двойной клик (клик выделяет)</string>
     <string name="settings_terminal_clipboard_write_desc">Удалённая сторона может писать в системный буфер (tmux/vim). По умолчанию выкл.</string>
+    <string name="settings_terminal_sudo_password">Предлагать сохранённый пароль для sudo</string>
+    <string name="settings_terminal_sudo_password_desc">На запрос sudo для этой учётной записи появляется подсказка; Enter отправляет пароль, с которым открыта сессия. По умолчанию выкл. — вывод может имитировать запрос.</string>
 
     <!-- Раздел Sync (включая карточку аккаунта и устройства — бывшая вкладка Account влита сюда) -->
     <string name="settings_disconnect">Отключить</string>
@@ -216,6 +218,7 @@
     <string name="settings_kb_accept_autocomplete">Принять подсказку автодополнения</string>
     <string name="settings_kb_cycle_suggestions">Перебрать подсказки</string>
     <string name="settings_kb_search_history">Поиск по истории команд</string>
+    <string name="settings_kb_sudo_password">Отправить сохранённый пароль в sudo</string>
     <string name="settings_kb_open_link_or_path">Открыть ссылку или файловый путь</string>
     <string name="settings_kb_mouse_click">Ctrl+клик</string>
     <string name="settings_kb_search_output">Поиск по выводу</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -157,4 +157,5 @@
     <string name="term_key_insert">Вставить совпадение</string>
     <string name="term_key_armed">взведён</string>
     <string name="term_key_open">открыт</string>
+    <string name="term_sudo_offer">Enter — отправить сохранённый пароль для %1$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -115,6 +115,8 @@
     <string name="settings_terminal_host_connect_single">单击</string>
     <string name="settings_terminal_host_connect_double">双击（单击选中）</string>
     <string name="settings_terminal_clipboard_write_desc">允许远端写入系统剪贴板（tmux/vim）。默认关闭。</string>
+    <string name="settings_terminal_sudo_password">向 sudo 提供已保存的密码</string>
+    <string name="settings_terminal_sudo_password_desc">针对该账户的 sudo 提示会显示提醒；按 Enter 发送本次会话连接所用的密码。默认关闭——输出可以伪装成提示。</string>
 
     <!-- 同步部分 -->
     <string name="settings_disconnect">断开连接</string>
@@ -216,6 +218,7 @@
     <string name="settings_kb_accept_autocomplete">接受自动补全建议</string>
     <string name="settings_kb_cycle_suggestions">循环切换建议</string>
     <string name="settings_kb_search_history">搜索命令历史</string>
+    <string name="settings_kb_sudo_password">向 sudo 发送已保存的密码</string>
     <string name="settings_kb_open_link_or_path">打开链接或文件路径</string>
     <string name="settings_kb_mouse_click">Ctrl+点击</string>
     <string name="settings_kb_search_output">在输出中查找</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -154,4 +154,5 @@
     <string name="term_key_insert">插入匹配项</string>
     <string name="term_key_armed">已启用</string>
     <string name="term_key_open">已打开</string>
+    <string name="term_sudo_offer">Enter — 发送 %1$s 的已保存密码</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -115,6 +115,8 @@
     <string name="settings_terminal_host_connect_single">Single click</string>
     <string name="settings_terminal_host_connect_double">Double click (click selects)</string>
     <string name="settings_terminal_clipboard_write_desc">The remote side may write to the system clipboard (tmux/vim). Off by default.</string>
+    <string name="settings_terminal_sudo_password">Offer the saved password to sudo</string>
+    <string name="settings_terminal_sudo_password_desc">A sudo prompt for this account gets a hint; Enter sends the password the session connected with. Off by default — output can imitate a prompt.</string>
 
     <!-- Sync section (also covers the account card and linked devices — merged from the former Account tab) -->
     <string name="settings_disconnect">Disconnect</string>
@@ -216,6 +218,7 @@
     <string name="settings_kb_accept_autocomplete">Accept autocomplete suggestion</string>
     <string name="settings_kb_cycle_suggestions">Cycle suggestions</string>
     <string name="settings_kb_search_history">Search command history</string>
+    <string name="settings_kb_sudo_password">Send the saved password to sudo</string>
     <string name="settings_kb_open_link_or_path">Open a link or file path</string>
     <string name="settings_kb_mouse_click">Ctrl+click</string>
     <string name="settings_kb_search_output">Find in output</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -158,4 +158,5 @@
     <string name="term_key_insert">Insert match</string>
     <string name="term_key_armed">armed</string>
     <string name="term_key_open">open</string>
+    <string name="term_sudo_offer">Enter — send the saved password for %1$s</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopSettingsState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopSettingsState.kt
@@ -55,6 +55,8 @@ class DesktopSettingsState(
     private val onHostClickConnectModeChange: (HostClickConnectMode) -> Unit = {},
     initialAllowServerClipboardWrite: Boolean = false,
     private val onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    initialOfferSudoPassword: Boolean = false,
+    private val onOfferSudoPasswordChange: (Boolean) -> Unit = {},
     initialReportTeamSessions: Boolean = true,
     private val onReportTeamSessionsChange: (Boolean) -> Unit = {},
     initialOpenFilePathsInSftp: Boolean = true,
@@ -128,6 +130,14 @@ class DesktopSettingsState(
      * write). Off by default; snapshotted into new sessions and pushed live into open ones.
      */
     var allowServerClipboardWrite: Boolean by mutableStateOf(initialAllowServerClipboardWrite); private set
+
+    /**
+     * Whether a sudo prompt is offered the password this session authenticated with (Terminal ->
+     * "Offer the saved password to sudo", issue #360). Off by default: nothing is ever sent without
+     * an explicit Enter, but the prompt is only recognised heuristically, so the user opts in.
+     * Snapshotted into new sessions - an open one keeps the answer it was born with.
+     */
+    var offerSudoPassword: Boolean by mutableStateOf(initialOfferSudoPassword); private set
 
     /**
      * Whether opening a session on a host **shared with a team** is reported to that team's activity
@@ -314,6 +324,12 @@ class DesktopSettingsState(
     fun toggleAllowServerClipboardWrite() {
         allowServerClipboardWrite = !allowServerClipboardWrite
         onAllowServerClipboardWriteChange(allowServerClipboardWrite)
+    }
+
+    /** Toggle offering the saved password at a sudo prompt and report outward (for persistence). */
+    fun toggleOfferSudoPassword() {
+        offerSudoPassword = !offerSudoPassword
+        onOfferSudoPasswordChange(offerSudoPassword)
     }
 
     /** Toggle reporting sessions on team-shared hosts and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -161,6 +161,8 @@ class MobileDesignState(
     // and pushed live into open ones. Persisted on Android; no-op default for previews/tests.
     initialAllowServerClipboardWrite: Boolean = false,
     private val onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    initialOfferSudoPassword: Boolean = false,
+    private val onOfferSudoPasswordChange: (Boolean) -> Unit = {},
     initialReportTeamSessions: Boolean = true,
     private val onReportTeamSessionsChange: (Boolean) -> Unit = {},
     // Whether a file path selected in terminal output offers "Open in Files" (More → Terminal).
@@ -405,6 +407,14 @@ class MobileDesignState(
     var allowServerClipboardWrite: Boolean by mutableStateOf(initialAllowServerClipboardWrite); private set
 
     /**
+     * Whether a sudo prompt is offered the password this session authenticated with (Terminal ->
+     * "Offer the saved password to sudo", issue #360). Off by default: nothing is ever sent without
+     * an explicit Enter, but the prompt is only recognised heuristically, so the user opts in.
+     * Snapshotted into new sessions - an open one keeps the answer it was born with.
+     */
+    var offerSudoPassword: Boolean by mutableStateOf(initialOfferSudoPassword); private set
+
+    /**
      * Whether a session on a team-shared host is reported to that team's activity feed (More →
      * Security). Desktop parity, see [app.skerry.ui.app.DesktopDesignState.reportTeamSessions].
      */
@@ -534,6 +544,12 @@ class MobileDesignState(
     fun toggleAllowServerClipboardWrite() {
         allowServerClipboardWrite = !allowServerClipboardWrite
         onAllowServerClipboardWriteChange(allowServerClipboardWrite)
+    }
+
+    /** Toggle offering the saved password at a sudo prompt and report outward (for persistence). */
+    fun toggleOfferSudoPassword() {
+        offerSudoPassword = !offerSudoPassword
+        onOfferSudoPasswordChange(offerSudoPassword)
     }
 
     /** Toggle reporting sessions on team-shared hosts and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -327,6 +327,39 @@ class ConnectionController(
     }
 
     /**
+     * The terminal for a session just opened on [channel]: the emulator's settings snapshotted at
+     * connect time (they apply to the new session; an open one keeps its own), this host's command
+     * history under [historyKey] with the hook that persists it, and the sudo offer built from the
+     * credential the connection is actually using (see [sudoOfferFor]).
+     */
+    private fun newTerminal(
+        target: SshTarget,
+        auth: SshAuth,
+        channel: ShellChannel,
+        sScope: CoroutineScope,
+        historyKey: String,
+    ): TerminalScreenState {
+        val prefs = terminalPrefs()
+        return TerminalScreenState(
+            ShellTerminalSession(channel, sScope),
+            sScope,
+            initialHistory = history?.load(historyKey).orEmpty(),
+            scrollback = prefs.effectiveScrollback,
+            cursorShape = prefs.cursorStyle.shape,
+            cursorBlink = prefs.cursorStyle.blink,
+            clipboardWriteEnabled = prefs.clipboardWriteEnabled,
+            sudo = sudoOfferFor(target, auth, prefs.sudoPasswordEnabled),
+            onHistoryChanged = history?.let { store ->
+                // Moves the write off the UI thread onto the controller's scope (Default): commands
+                // are infrequent and the write is small. The label rides along so the command
+                // palette can name the host a command came from.
+                val label = "${target.username}@${target.host}"
+                { snapshot -> scope.launch { store.save(historyKey, snapshot, label) } }
+            },
+        )
+    }
+
+    /**
      * Establishes a live session to [target]/[auth]: opens the connection and shell, assembles the
      * terminal, transitions to [ConnectionUiState.Connected], and subscribes the drop observer. On
      * any error, closes the half-open connection and rethrows (the caller decides: show [Error] or
@@ -355,25 +388,7 @@ class ConnectionController(
                 target.connectionType.name, target.username, target.host, target.port,
             )
             this.historyKey = historyKey
-            val loadedHistory = history?.load(historyKey).orEmpty()
-            // Snapshot terminal settings at connect time: they apply to the new session.
-            val prefs = terminalPrefs()
-            val terminal = TerminalScreenState(
-                ShellTerminalSession(channel, sScope),
-                sScope,
-                initialHistory = loadedHistory,
-                scrollback = prefs.effectiveScrollback,
-                cursorShape = prefs.cursorStyle.shape,
-                cursorBlink = prefs.cursorStyle.blink,
-                clipboardWriteEnabled = prefs.clipboardWriteEnabled,
-                onHistoryChanged = history?.let { store ->
-                    // Moves the write off the UI thread onto the controller's scope (Default):
-                    // commands are infrequent and the write is small. The label rides along so the
-                    // command palette can name the host a command came from.
-                    val label = "${target.username}@${target.host}"
-                    { snapshot -> scope.launch { store.save(historyKey, snapshot, label) } }
-                },
-            )
+            val terminal = newTerminal(target, auth, channel, sScope, historyKey)
             // Keep-alive per the profile's cadence (0 = off, SSH-only): pings run from the moment
             // the session exists — not lazily from the status bar — so an idle session behind a NAT
             // stays alive even with no UI polling it. Created BEFORE Connected (like shellChannel)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
@@ -10,6 +10,7 @@ import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vnc.VncAuth
 import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.terminal.SudoPasswordOffer
 
 /**
  * Pure helpers wiring a saved host profile to a live session. Kept separate from UI so the
@@ -67,6 +68,29 @@ fun Credential.toSshAuth(): SshAuth = when (val s = secret) {
     // Refs travel as refs: the files behind them are read by the transport at connect time, so a
     // certificate the issuer rewrote a minute ago is the one presented.
     is CredentialSecret.KeyFile -> SshAuth.KeyFile(s.privateKeyRef, s.certificateRef, s.passphrase)
+}
+
+/**
+ * The sudo offer for a session authenticating as [target] with [auth] (issue #360), or `null` when
+ * there is nothing to offer: [enabled] is off, the profile does not authenticate with a password —
+ * a key-based session has no secret a prompt could be answered with — or it carries no account name
+ * for a prompt to be matched against.
+ *
+ * Built from the credential the connection is actually using rather than from a vault lookup, which
+ * is what makes "only the credential belonging to the current host/user" true by construction: what
+ * may be offered back is exactly what got in.
+ */
+fun sudoOfferFor(target: SshTarget, auth: SshAuth, enabled: Boolean): SudoPasswordOffer? {
+    if (!enabled) return null
+    // A container profile execs into an image once the host's SSH leg is up, so the shell on screen
+    // is not the account that authenticated: a container with a same-named user printing a sudo
+    // prompt would be handed the host's password, and an image is a far weaker trust boundary than
+    // the host running it. Nesting the user does by hand (an inner ssh, su, docker exec) cannot be
+    // detected from here - which is why the hint names the account and host the password belongs to.
+    if (target.connectionType == ConnectionType.CONTAINER) return null
+    val password = (auth as? SshAuth.Password)?.secret?.takeIf { it.isNotEmpty() } ?: return null
+    val username = target.username.trim().takeIf { it.isNotEmpty() } ?: return null
+    return SudoPasswordOffer(username, untrustedLabel("$username@${target.host}"), password)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -268,6 +268,7 @@ fun DesktopDesignApp(
                                 state.settings.terminalScrollback,
                                 state.settings.terminalCursorStyle,
                                 clipboardWriteEnabled = state.settings.allowServerClipboardWrite,
+                                sudoPasswordEnabled = state.settings.offerSudoPassword,
                             )
                         },
                     )
@@ -307,6 +308,14 @@ fun DesktopDesignApp(
     LaunchedEffect(allowClipboardWrite, liveSessions) {
         val manager = liveSessions ?: return@LaunchedEffect
         manager.allSessions.forEach { it.liveTerminal?.applyClipboardWriteEnabled(allowClipboardWrite) }
+    }
+    // Turning the saved-password offer off applies to ALREADY open sessions live: the offer ends and
+    // the password is dropped. One direction only - a session that connected without one has no
+    // credential to build it from, so turning the setting on takes effect at the next connect.
+    val offerSudoPassword = state.settings.offerSudoPassword
+    LaunchedEffect(offerSudoPassword, liveSessions) {
+        val manager = liveSessions ?: return@LaunchedEffect
+        manager.allSessions.forEach { it.liveTerminal?.applySudoOfferEnabled(offerSudoPassword) }
     }
     // Memoized: LocalTerminalAppearance is staticCompositionLocalOf (reference comparison), and
     // DesktopDesignApp recomposes on tab/session switches and vault events. Without remember a new

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppearanceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppearanceScreen.kt
@@ -60,6 +60,8 @@ import app.skerry.ui.generated.resources.settings_terminal_highlight_output
 import app.skerry.ui.generated.resources.settings_terminal_highlight_output_desc
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write_desc
+import app.skerry.ui.generated.resources.settings_terminal_sudo_password
+import app.skerry.ui.generated.resources.settings_terminal_sudo_password_desc
 import app.skerry.ui.generated.resources.settings_terminal_cursor_style
 import app.skerry.ui.generated.resources.settings_terminal_scrollback
 import app.skerry.ui.generated.resources.appearance_title
@@ -208,6 +210,16 @@ fun MobileAppearanceScreen(state: MobileDesignState) {
                 desc = stringResource(Res.string.settings_terminal_clipboard_write_desc),
                 on = state.allowServerClipboardWrite,
                 onToggle = state::toggleAllowServerClipboardWrite,
+            )
+            // Saved password offered back at a sudo prompt (issue #360, desktop parity). Default
+            // off: nothing is sent without an explicit Enter, but the prompt is only recognised
+            // heuristically and the secret is the session's own credential.
+            HLine()
+            MobileToggleRow(
+                title = stringResource(Res.string.settings_terminal_sudo_password),
+                desc = stringResource(Res.string.settings_terminal_sudo_password_desc),
+                on = state.offerSudoPassword,
+                onToggle = state::toggleOfferSudoPassword,
             )
             // Production guard threshold (desktop parity): dangerous commands always confirm, the
             // warnings on top of them are opt-in.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -138,6 +138,7 @@ fun MobileDesignApp(
                                 state.terminalScrollback,
                                 state.terminalCursorStyle,
                                 clipboardWriteEnabled = state.allowServerClipboardWrite,
+                                sudoPasswordEnabled = state.offerSudoPassword,
                             )
                         },
                     )
@@ -170,6 +171,13 @@ fun MobileDesignApp(
     LaunchedEffect(allowClipboardWrite, liveSessions) {
         val manager = liveSessions ?: return@LaunchedEffect
         manager.allSessions.forEach { it.liveTerminal?.applyClipboardWriteEnabled(allowClipboardWrite) }
+    }
+    // Desktop parity: turning the saved-password offer off ends it in already-open sessions and
+    // drops the password (see DesktopDesignApp).
+    val offerSudoPassword = state.offerSudoPassword
+    LaunchedEffect(offerSudoPassword, liveSessions) {
+        val manager = liveSessions ?: return@LaunchedEffect
+        manager.allSessions.forEach { it.liveTerminal?.applySudoOfferEnabled(offerSudoPassword) }
     }
     // Memoized: LocalTerminalAppearance is staticCompositionLocalOf (reference comparison); without
     // remember a new instance on every recomposition would force a rebuild of the terminal subtree.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/PaneSync.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/PaneSync.kt
@@ -47,8 +47,12 @@ internal fun mirrorPaneInput(tab: Tab, originPaneId: String, text: String, kind:
     val origin = tab.pane(originPaneId)?.liveTerminal
     paneSyncTargets(origin, tab.syncTargetsFrom(originPaneId)).forEach { target ->
         when (kind) {
-            MirroredInput.Typed -> target.typeInput(text, guarded = false, mirror = false)
+            MirroredInput.Typed -> target.receiveMirrored(text)
             MirroredInput.Pasted -> target.paste(text, mirror = false)
+            // The origin answered its own sudo prompt with its own saved password; this pane
+            // answers its own with its own. The secret itself is never mirrored — the panes are
+            // separate hosts, and one host's password has no business on another's tty.
+            MirroredInput.SudoAnswer -> target.answerSudoPrompt()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
@@ -59,6 +59,7 @@ import app.skerry.ui.generated.resources.settings_kb_record_session
 import app.skerry.ui.generated.resources.settings_kb_release_keyboard
 import app.skerry.ui.generated.resources.settings_kb_remote_group
 import app.skerry.ui.generated.resources.settings_kb_search_history
+import app.skerry.ui.generated.resources.settings_kb_sudo_password
 import app.skerry.ui.generated.resources.settings_kb_search_output
 import app.skerry.ui.generated.resources.settings_kb_open_link_or_path
 import app.skerry.ui.generated.resources.settings_kb_mouse_click
@@ -114,6 +115,9 @@ internal fun KeyboardSection() {
         // Find in the session's output: the panel's own keys (Enter / Shift+Enter / Esc) are listed
         // with it, since they only exist while it is open.
         KeyboardBinding(stringResource(Res.string.settings_kb_search_output), "${mod("F")} · Enter / ${shift("Enter")} · Esc", live = true),
+        // Only while the saved-password offer is on screen (Settings -> Terminal), like the find
+        // panel's keys above: Enter then sends the password instead of a bare newline.
+        KeyboardBinding(stringResource(Res.string.settings_kb_sudo_password), "Enter", live = true),
         // Both conventions are live, so both are listed: Ctrl+Shift+C/V and the X11 Insert pair.
         // Both conventions work, so both are listed: Ctrl+Shift+C/V and the X11 Insert pair.
         KeyboardBinding(stringResource(Res.string.settings_kb_copy_selection), "${ctrlShift("C")} / ${ctrl("Insert")}", live = true),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -60,6 +60,8 @@ import app.skerry.ui.generated.resources.settings_terminal_highlight_output
 import app.skerry.ui.generated.resources.settings_terminal_highlight_output_desc
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write_desc
+import app.skerry.ui.generated.resources.settings_terminal_sudo_password
+import app.skerry.ui.generated.resources.settings_terminal_sudo_password_desc
 import app.skerry.ui.generated.resources.settings_terminal_scrollback
 import app.skerry.ui.generated.resources.settings_terminal_scrollback_desc
 import app.skerry.ui.generated.resources.settings_terminal_section_behavior
@@ -224,6 +226,16 @@ internal fun TerminalSection(state: DesktopDesignState) {
         stringResource(Res.string.settings_terminal_clipboard_write_desc),
         on = state.settings.allowServerClipboardWrite,
         onToggle = state.settings::toggleAllowServerClipboardWrite,
+    )
+    HLine()
+    // Saved password offered back at a sudo prompt (issue #360). Default off: nothing is sent
+    // without an explicit Enter, but the prompt is only recognised heuristically and the secret is
+    // the session's own credential.
+    SettingToggleRow(
+        stringResource(Res.string.settings_terminal_sudo_password),
+        stringResource(Res.string.settings_terminal_sudo_password_desc),
+        on = state.settings.offerSudoPassword,
+        onToggle = state.settings::toggleOfferSudoPassword,
     )
     HLine(modifier = Modifier.padding(top = 12.dp))
     // Local shell: the shell binary run for local-terminal sessions (launched from the empty-tab

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SudoPasswordOffer.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SudoPasswordOffer.kt
@@ -1,0 +1,151 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import app.skerry.shared.terminal.isSudoPasswordPrompt
+import kotlin.concurrent.Volatile
+
+/**
+ * The cursor row an offer is anchored to: where it sits in the buffer and what it says. Both halves
+ * are needed to tell one prompt from the next — sudo re-asking after a wrong password prints the
+ * same words on a new row, and a row that merely repainted says something else.
+ */
+data class PromptRow(val row: Int, val text: String)
+
+/**
+ * How long a prompt has to have been on screen before Enter may answer it with the saved password.
+ *
+ * This is the whole difference between the user confirming an offer and the host harvesting a
+ * keystroke. Any process on the connected machine can write to the tty, so it can print a prompt of
+ * its own the instant before an Enter the user was already going to press — for the newline ending
+ * the command they just typed. Without a dwell that Enter would hand it the account's SSH password,
+ * which is a password sshd checked and that process never saw. Requiring the offer to have been
+ * standing first means the keypress answers something the user had time to read.
+ */
+internal const val OFFER_DWELL_MS = 500L
+
+/**
+ * The password this session authenticated with, held so it can be offered back to a `sudo` prompt
+ * for the same account (issue #360). Opt-in: a session is given one only when Terminal → "Offer the
+ * saved password to sudo" is on and the profile actually authenticates with a password.
+ *
+ * The offer never sends anything by itself. A remote process can print whatever it likes, a
+ * convincing prompt included, so what turns the offer into bytes on the wire is a keypress the user
+ * made while the offer stood on screen — the same act as typing the password, with the client
+ * naming whose secret it is about to hand over first. Everything here exists to keep that one act
+ * honest:
+ *
+ * * [observe] is the only way an offer arms, and it arms nothing that is not sudo asking *this*
+ *   account ([isSudoPasswordPrompt]);
+ * * [take] answers only after [OFFER_DWELL_MS] on the same row, so the keypress belongs to a prompt
+ *   the user saw rather than to one drawn underneath it;
+ * * [decline] is what any other input does — the user is entering a password themselves, and the
+ *   Enter that ends it must commit what they entered;
+ * * [revoke] ends the offer for good when the setting goes off or the session closes.
+ *
+ * Arming is anchored to the row rather than latched, which is what lets sudo's re-ask after a wrong
+ * password be answered again while the prompt already answered stays answered — each re-ask serving
+ * its own dwell. Where the two cannot be told apart — a full scrollback pins the cursor to the same
+ * row index and the re-ask says the same words — the offer stays spent and the password is typed by
+ * hand: a heuristic that fails by not offering costs a keystroke, one that fails by offering costs
+ * the secret.
+ *
+ * [take] and [decline] run on the UI thread while [observe] runs on the emulator's own coroutine, so
+ * a keystroke can race a redraw. The states are snapshot-backed and the loser of such a race finds
+ * the offer already gone: [take] then returns null and its caller delivers the keystroke as the
+ * plain Enter it was, which is why nothing here may be the only thing that acts on a keypress.
+ *
+ * The password is a secret and is redacted from `toString` like every other one in the app; it lives
+ * as a `String` for the same reason [app.skerry.shared.vault.CredentialSecret] does (the JVM cannot
+ * zero one), which is why [revoke] drops the reference as soon as the session has no use for it.
+ */
+@Stable
+class SudoPasswordOffer(
+    private val username: String,
+    /** Account and host as the hint names them, so a user nested elsewhere sees the mismatch. */
+    val account: String,
+    password: String,
+    private val dwellMillis: Long = OFFER_DWELL_MS,
+) {
+
+    /** The prompt on screen and when it got there, or null when no offer stands. */
+    private var standing: Standing? by mutableStateOf(null)
+
+    /** The prompt this offer was already answered on — by being taken, or by being declined. */
+    private var spentAt: PromptRow? by mutableStateOf(null)
+
+    /**
+     * The password, until [revoke] drops it. A plain field, not snapshot state: nothing in a
+     * composition reads it, and `mutableStateOf` would defeat the drop. A snapshot state object
+     * keeps its previous record until another write can recycle it, and `secret = null` is the last
+     * write there ever is — so the record holding the plaintext would stay reachable from the pane
+     * for the rest of the process, which is exactly what the vault lock calls [revoke] to prevent.
+     * Volatile because [observe] reads it from the emulator's coroutine, while [take] writes it
+     * from the UI thread and [revoke] from whichever of the two ends the offer — the vault lock on
+     * the UI thread, or the session's own teardown on that coroutine.
+     */
+    @Volatile
+    private var secret: String? = password
+
+    /** Whether an offer stands right now. Snapshot state: the hint recomposes when it changes. */
+    val stands: Boolean get() = standing != null
+
+    /**
+     * Take in the cursor row as it was just drawn. Arms the offer when the row is a prompt for this
+     * account that has not been answered, restarts the dwell whenever the row changes, and disarms
+     * as soon as the prompt is no longer what the cursor is on.
+     */
+    fun observe(prompt: PromptRow, now: Long) {
+        // Disarming on a dead offer is unconditional, not an early return: [revoke] writes the
+        // secret and the standing state one after the other, and a redraw landing between the two
+        // could otherwise leave the hint on screen for the rest of the session with nothing behind
+        // it. Any stray arming heals on the next row drawn.
+        if (secret == null) {
+            standing = null
+            return
+        }
+        val current = standing
+        if (current?.prompt == prompt) return // same row, still standing: its dwell keeps running
+        standing = if (prompt != spentAt && isSudoPasswordPrompt(prompt.text, username)) {
+            Standing(prompt, now)
+        } else {
+            null
+        }
+    }
+
+    /**
+     * The password, once, if an offer has stood long enough to have been read. Null when there is
+     * none, when the dwell is unserved, or when a redraw took the offer away first — the caller
+     * must then deliver the keystroke normally.
+     */
+    fun take(now: Long): String? {
+        val current = standing ?: return null
+        if (now - current.since < dwellMillis) return null
+        spentAt = current.prompt
+        standing = null
+        return secret
+    }
+
+    /** The user is answering the prompt themselves; this offer is over. */
+    fun decline() {
+        val current = standing ?: return
+        spentAt = current.prompt
+        standing = null
+    }
+
+    /**
+     * End the offer and drop the password. Called when the setting is turned off under a live
+     * session and when the session closes: the credential outliving its connection is what the
+     * connection controller already avoids by dropping its own copy.
+     */
+    fun revoke() {
+        secret = null
+        standing = null
+    }
+
+    override fun toString(): String = "SudoPasswordOffer(account=$account, password=redacted)"
+
+    private data class Standing(val prompt: PromptRow, val since: Long)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalAppearance.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalAppearance.kt
@@ -135,6 +135,10 @@ data class TerminalSessionPrefs(
     // clipboard write"). Off by default (like xterm/kitty): an untrusted host can't silently
     // overwrite the clipboard until the user opts in.
     val clipboardWriteEnabled: Boolean = false,
+    // Whether a sudo prompt is offered the password the session authenticated with (Terminal ->
+    // "Offer the saved password to sudo", issue #360). Off by default: it hands a secret to a line
+    // the client only recognises heuristically, so the user opts in.
+    val sudoPasswordEnabled: Boolean = false,
 ) {
     /** Effective scrollback depth: validated preset, else the emulator default (safety net). */
     val effectiveScrollback: Int get() = scrollback.takeIf { it > 0 } ?: DEFAULT_MAX_SCROLLBACK

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalCursorLine.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalCursorLine.kt
@@ -1,0 +1,104 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.wrapsToNextRow
+
+/**
+ * The shell line the cursor sits on, read off a published screen snapshot.
+ *
+ * Every reader here — the production guard, the autocomplete ghost, the password-prompt detectors —
+ * asks about the same line from the same snapshot, so the reads live together rather than as
+ * methods on the state that publishes it. [row] indexes the snapshot directly (the emulator counts
+ * scrollback into it), so it must NOT be offset by the screen's start — doing that ran off the end
+ * as soon as any history existed, and the guard then saw an empty line.
+ */
+internal class CursorLine(
+    private val grid: List<List<TermCell>>,
+    private val row: Int,
+    private val col: Int,
+    private val rows: Int,
+) {
+    private val line: List<TermCell>? =
+        if (grid.isEmpty() || rows <= 0) null else grid.getOrNull(row)
+
+    /**
+     * The cursor row as drawn, or "" when there is no screen yet. What the password-prompt
+     * classifiers read: a prompt is one row, and joining the wrapped ones would let output above it
+     * decide whether a saved password is offered.
+     */
+    fun rowText(): String = line?.joinToString("") { it.text } ?: ""
+
+    /**
+     * Visible cursor row up to the cursor column — the shell line as the user sees it, prompt
+     * included ([ProductionGuard.promptCandidates] strips it).
+     */
+    fun toCursor(): String {
+        val cells = line ?: return ""
+        return cells.take(col.coerceIn(0, cells.size)).joinToString("") { it.text }
+    }
+
+    /**
+     * The whole visible shell line, joined across its soft-wrapped rows, trailing blanks trimmed.
+     * Beside [toCursor] because the guard needs both: the shell runs the LINE, not the part of it
+     * left of the cursor — a recalled line with the cursor stepped back inside it is longer than
+     * what the cursor bounds, and one that wrapped leaves the cursor on the tail row with the head,
+     * where the risk usually sits, above it. Bounded by the grid.
+     */
+    fun logicalText(): String {
+        if (line == null) return ""
+        return buildString {
+            for (at in logicalLineRows()) grid[at].forEach { append(it.text) }
+        }.trimEnd()
+    }
+
+    /**
+     * Whether the shell's line continues past the cursor. Measured in CELLS, never in string
+     * characters: a wide glyph is one character in two columns (its continuation cell draws
+     * nothing) and a combining sequence is several characters in one, while [col] is a column —
+     * comparing against a joined string's length called a CJK row complete with text still right of
+     * the cursor. Counted across the logical line's soft-wrapped rows, so a cursor inside a wrapped
+     * line reports the tail rows too — and a cursor at the very end of the last one honestly
+     * reports nothing left.
+     */
+    fun continues(): Boolean {
+        val cells = line ?: return false
+        val lineRows = logicalLineRows()
+        // Clamped to the row as [toCursor] clamps: a cursor parked past the row's width would
+        // overcount what is behind it and call a continuing line complete.
+        var beforeCursor = col.coerceIn(0, cells.size)
+        for (at in lineRows.first until row) beforeCursor += grid[at].size
+        var total = 0
+        for (at in lineRows) {
+            val cellsOfRow = grid[at]
+            var width = cellsOfRow.size
+            if (at == lineRows.last) while (width > 0 && cellsOfRow[width - 1].text.isBlank()) width--
+            total += width
+        }
+        return total > beforeCursor
+    }
+
+    /**
+     * Rows of the logical line the cursor sits in: soft-wrap joined, up and down from the cursor
+     * row. Capped, not merely grid-bounded: the snapshot includes scrollback, and a host that never
+     * prints a newline chains wrap flags across thousands of rows — joining them would build a
+     * megabyte string on the caller's thread for a classifier that reads 512 characters of a
+     * candidate. The window keeps the rows nearest the cursor, which are the ones the shell's line
+     * actually lives on; past it the join degrades to what the old single-row read saw.
+     */
+    private fun logicalLineRows(): IntRange {
+        var first = row
+        while (
+            first > 0 && row - first < MAX_JOINED_WRAP_ROWS &&
+            grid.getOrNull(first - 1)?.wrapsToNextRow() == true
+        ) first--
+        var last = row
+        while (
+            last - row < MAX_JOINED_WRAP_ROWS && last + 1 < grid.size &&
+            grid.getOrNull(last)?.wrapsToNextRow() == true
+        ) last++
+        return first..last
+    }
+}
+
+/** How many soft-wrapped rows [CursorLine.logicalLineRows] joins in each direction. */
+private const val MAX_JOINED_WRAP_ROWS = 64

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalOverlayBanner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalOverlayBanner.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.design.LocalFonts
@@ -33,6 +34,11 @@ internal fun shouldShowCopiedFlash(nonce: Int): Boolean = nonce != 0
  * one line of mono text, a translucent [background] and a 40%-[accent] border. [contentColor] defaults
  * to [accent] but can differ (e.g. a brighter foreground on a dark accent). [modifier] positions it
  * (typically `Modifier.align(Alignment.TopCenter)`).
+ *
+ * [announced] says the caller already speaks this text through a [app.skerry.ui.design.StatusAnnouncer],
+ * which takes the pill out of the semantics tree: otherwise a screen reader swiping the terminal meets
+ * the announcer's node and the pill's own text one after the other and reads the same sentence twice.
+ * Default false — the banners that carry no announcer are only readable because their text is there.
  */
 @Composable
 internal fun TerminalOverlayBanner(
@@ -42,10 +48,12 @@ internal fun TerminalOverlayBanner(
     background: Color,
     modifier: Modifier = Modifier,
     contentColor: Color = accent,
+    announced: Boolean = false,
 ) {
     val mono = LocalFonts.current.mono
     Row(
         modifier
+            .then(if (announced) Modifier.clearAndSetSemantics {} else Modifier)
             .padding(top = 10.dp)
             .clip(RoundedCornerShape(6.dp))
             .background(background)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -105,9 +105,11 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 import org.jetbrains.compose.resources.stringResource
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.terminal_reverse_search_no_matches
 import app.skerry.ui.generated.resources.terminal_reverse_search_prompt
+import app.skerry.ui.generated.resources.term_sudo_offer
 import app.skerry.ui.theme.Skerry
 
 /** Max gap (ms) between clicks to count as double/triple click. */
@@ -1406,5 +1408,27 @@ fun TerminalScreen(
       // Transient "Copied" confirmation over the top of the terminal (right-click / Ctrl+Shift+C /
       // touch "Copy"). Same overlay slot and visual language as the DisconnectedBanner in TerminalView.
       CopiedBanner(copiedNonce, Modifier.align(Alignment.TopCenter))
+
+      // The saved password offered to a sudo prompt (issue #360). Bottom edge, not the top one the
+      // copy flash and the find bar share: the prompt it answers is on one of the last rows, and the
+      // hint has to be read together with it. Nothing is sent until Enter is pressed - see
+      // [SudoPasswordOffer] - so this line is the whole of the user's warning that the client is
+      // holding a secret ready, and it is announced as well as drawn.
+      // Read once: two reads of a snapshot value could straddle a commit and announce a hint the
+      // frame does not draw. The account and host are named because the client cannot tell it is
+      // still talking to them - an inner ssh or su leaves the prompt looking the same.
+      val sudoOffer = state.sudoOffer && !closed
+      val sudoHint = stringResource(Res.string.term_sudo_offer, state.sudoAccount)
+      StatusAnnouncer(if (sudoOffer) sudoHint else "")
+      if (sudoOffer) {
+          TerminalOverlayBanner(
+              icon = "password",
+              text = sudoHint,
+              accent = Skerry.colors.amber,
+              background = Skerry.colors.bannerScrim,
+              modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 10.dp),
+              announced = true,
+          )
+      }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -16,6 +16,7 @@ import app.skerry.shared.terminal.DEFAULT_MAX_SCROLLBACK
 import app.skerry.shared.terminal.MouseButton
 import app.skerry.shared.terminal.SessionRecorder
 import app.skerry.shared.terminal.epochMillis
+import app.skerry.shared.terminal.isPasswordPrompt
 import app.skerry.shared.terminal.MouseEventType
 import app.skerry.shared.terminal.MouseTracking
 import app.skerry.shared.terminal.TermCell
@@ -25,7 +26,6 @@ import app.skerry.shared.terminal.TerminalPos
 import app.skerry.shared.terminal.TerminalSelection
 import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
-import app.skerry.shared.terminal.wrapsToNextRow
 import app.skerry.shared.terminal.TerminalStepMark
 import app.skerry.shared.terminal.bracketedPasteWrap
 import app.skerry.shared.terminal.encodeMouseReport
@@ -80,6 +80,10 @@ class TerminalScreenState(
     // an untrusted host must not silently overwrite the system clipboard until the user opts in.
     // Snapshotted at connect; also pushed live into an open session via [applyClipboardWriteEnabled].
     clipboardWriteEnabled: Boolean = false,
+    // The password this session authenticated with, offered back at a sudo prompt for the same
+    // account (Terminal -> "Offer the saved password to sudo"). Null is the default and means the
+    // feature is off for this session: nothing here can then send anything the user did not type.
+    private val sudo: SudoPasswordOffer? = null,
     // Monotonic milliseconds, injectable for tests. Two readers: the search refresh throttle and
     // the publish-rate cap in the emulator owner loop. Must not step backwards (a wall clock
     // would) — a backwards step would skip search refreshes for minutes and stretch the publish
@@ -554,6 +558,15 @@ class TerminalScreenState(
         // clears it — the same window every cross-thread engine write already lives with.
         if (altScreen != emulator.altScreen) autocomplete.reset()
         altScreen = emulator.altScreen
+        // Arm or disarm the saved-password offer from the row that was just drawn, and stamp when
+        // it appeared: the dwell [SudoPasswordOffer.take] requires is measured from here, which is
+        // the only place that knows when the prompt reached the screen. Never on the alternate
+        // screen — a fullscreen TUI paints arbitrary text, a line reading like a sudo prompt
+        // included, and an Enter there edits a buffer.
+        sudo?.observe(
+            if (altScreen) PromptRow(-1, "") else PromptRow(cursorRow, cursorLine().rowText()),
+            nowMillis(),
+        )
         // The echo of what was typed arrives here, and the ghost continues what this snapshot shows —
         // so this is where it is recomputed. Also clears it on entering a fullscreen TUI (vim/htop):
         // there is no "line" there.
@@ -719,8 +732,24 @@ class TerminalScreenState(
      * reaches the tracked line only where the sender says what it did to it
      * ([TerminalCommandGuard.trackSent]).
      */
-    fun typeInput(text: String, guarded: Boolean = true, mirror: Boolean = true) {
+    fun typeInput(text: String, guarded: Boolean = true, mirror: Boolean = true, mirrored: Boolean = false) {
         inputVersion++
+        // The saved password offered at a sudo prompt (issue #360): Enter takes it, and anything
+        // else declines the offer and is forwarded normally. Ahead of the secret path below because
+        // this Enter is not input for the host at all - it is the answer to the client's own offer.
+        // Only a keypress made on this pane can take it: input mirrored from a synchronized pane
+        // was aimed at that pane's screen, and the user reading its prompt never saw this one.
+        if (sudo != null && sudoOffer) {
+            if (!mirrored && isEnterKey(text) && sendSudoPassword()) {
+                // Carries no bytes: each synchronized pane answers its own prompt with its own
+                // credential, and a pane with no offer standing is left alone. paneSyncTargets has
+                // already narrowed the fan-out to panes at a password prompt, so a bare Enter
+                // forwarded there would submit an empty password and burn one of their attempts.
+                if (mirror) inputMirror?.invoke(text, MirroredInput.SudoAnswer)
+                return
+            }
+            declineSudoOffer()
+        }
         // Server not echoing input (password entry / line-mode signaled by the transport): do not
         // track the line or write it to history, so a secret does not persist and surface as a
         // suggestion. SSH echo status is unavailable (always false), so a password prompt is also
@@ -801,9 +830,9 @@ class TerminalScreenState(
     private val guard = TerminalCommandGuard(
         engine = autocomplete,
         altScreen = { altScreen },
-        lineToCursor = ::screenLineToCursor,
-        rowText = ::screenRowText,
-        lineContinues = ::screenRowContinues,
+        lineToCursor = { cursorLine().toCursor() },
+        rowText = { cursorLine().logicalText() },
+        lineContinues = { cursorLine().continues() },
     )
 
     /**
@@ -869,100 +898,108 @@ class TerminalScreenState(
     fun dismissGuardedCommand() = guard.hold.dismiss()
 
     /**
-     * Visible cursor row up to the cursor column — the shell line as the user sees it, prompt
-     * included ([ProductionGuard.promptCandidates] strips it). Reads the published [screen]
-     * snapshot, like [atPasswordPrompt]. [cursorRow] indexes that snapshot directly (the emulator
-     * counts scrollback into it), so it must NOT be offset by the screen's start — doing that ran
-     * off the end as soon as any history existed, and the guard then saw an empty line.
+     * The shell line the cursor sits on, read off the published [screen] snapshot (UI thread, no
+     * race with the emulator). Built per call: it is a view over the snapshot, and the snapshot is
+     * replaced wholesale on every publish.
      */
-    private fun screenLineToCursor(): String {
-        val grid = screen
-        if (grid.isEmpty() || rows <= 0) return ""
-        val line = grid.getOrNull(cursorRow) ?: return ""
-        return line.take(cursorCol.coerceIn(0, line.size)).joinToString("") { it.text }
+    private fun cursorLine(): CursorLine = CursorLine(screen, cursorRow, cursorCol, rows)
+
+    /**
+     * Whether the current cursor row looks like a password prompt (echo is usually off there). The
+     * rule itself is [isPasswordPrompt], shared with the sudo detector so the two cannot disagree
+     * about what a prompt is — a row that offers the saved password but does not read as a prompt
+     * would put a hand-typed secret into history.
+     */
+    private fun atPasswordPrompt(): Boolean = isPasswordPrompt(cursorLine().rowText())
+
+    /**
+     * Whether an offer of the saved password stands on the prompt the cursor is on. Armed by the
+     * publish path ([SudoPasswordOffer.observe]) rather than computed here, so reading it costs a
+     * snapshot read per frame instead of joining the cursor row; the terminal draws its hint from
+     * this and [typeInput] turns the next Enter into the password. See [SudoPasswordOffer] for why
+     * an explicit keypress — and the dwell before it — is the whole of the safety here.
+     */
+    val sudoOffer: Boolean get() = sudo?.stands == true
+
+    /**
+     * The forms of Enter that may answer the saved-password offer: the two plain ones, plus the
+     * numpad's SS3 under application-keypad mode (DECKPAM), which a TUI can leave set behind it.
+     * Without that one the hint names a key that spends the offer on an empty answer instead of
+     * taking it. Deliberately narrower than [RUN_LINE_CONTROLS] otherwise: readline's Ctrl-O also
+     * runs the line, but the offer is answered by the key its hint names and by nothing else.
+     */
+    private fun isEnterKey(text: String): Boolean =
+        text == "\r" || text == "\n" || text == NUMPAD_ENTER_SS3
+
+    /** Whose password the hint says it is about to send, so a nested shell shows as a mismatch. */
+    val sudoAccount: String get() = sudo?.account.orEmpty()
+
+    /**
+     * The user is answering the prompt themselves — by typing, pasting, or from another surface.
+     * The Enter that ends what they are entering has to commit that, not the saved password.
+     */
+    private fun declineSudoOffer() {
+        sudo?.decline()
     }
 
     /**
-     * The whole visible shell line, joined across its soft-wrapped rows, trailing blanks trimmed.
-     * Beside [screenLineToCursor] because the guard needs both: the shell runs the LINE, not the
-     * part of it left of the cursor — a recalled line with the cursor stepped back inside it is
-     * longer than what the cursor bounds, and one that wrapped leaves the cursor on the tail row
-     * with the head, where the risk usually sits, above it. Bounded by the grid.
+     * Hand the saved password to the prompt on screen, if the offer still stands. Returns whether
+     * it was sent, because the caller has a keystroke in hand either way: an offer withdrawn by a
+     * redraw, a viewer of the shared session, or an unserved dwell must not swallow the Enter.
+     *
+     * Sent through [send], not [sendUserInput]: nothing about it belongs on the tracked line, and
+     * the secret itself is never mirrored into synchronized panes — it belongs to this session's
+     * host, and the pane beside it may be another one. What a pane mirrors is the answer, so each
+     * one answers its own prompt with its own credential ([MirroredInput.SudoAnswer]).
      */
-    private fun screenRowText(): String {
-        val grid = screen
-        if (grid.isEmpty() || rows <= 0) return ""
-        if (grid.getOrNull(cursorRow) == null) return ""
-        return buildString {
-            for (row in logicalLineRows(grid)) grid[row].forEach { append(it.text) }
-        }.trimEnd()
+    private fun sendSudoPassword(): Boolean {
+        val secret = sudo?.take(nowMillis()) ?: return false
+        // The same reset the secret path in [typeInput] makes: with the echo off nothing will
+        // redraw, and a ghost left over from the line the prompt interrupted would sit at the
+        // cursor of a password prompt.
+        autocomplete.reset()
+        refreshSuggestion()
+        send(secret + "\r")
+        return true
     }
 
     /**
-     * Whether the shell's line continues past the cursor. Measured in CELLS, never in string
-     * characters: a wide glyph is one character in two columns (its continuation cell draws
-     * nothing) and a combining sequence is several characters in one, while [cursorCol] is a
-     * column — comparing against a joined string's length called a CJK row complete with text
-     * still right of the cursor. Counted across the logical line's soft-wrapped rows, so a cursor
-     * inside a wrapped line reports the tail rows too — and a cursor at the very end of the last
-     * one honestly reports nothing left.
+     * Typed input arriving from a synchronized pane ([app.skerry.ui.session.mirrorPaneInput]).
+     *
+     * The one entry point for it, so the three things that make mirrored input different cannot be
+     * got wrong at a call site: the origin pane already held and confirmed the command for the whole
+     * group, a copy that mirrored again would bounce between panes forever, and — the one that
+     * carries a secret — a keypress made on another pane's screen must never take this pane's saved
+     * password. The user read that pane's prompt, not this one's.
      */
-    private fun screenRowContinues(): Boolean {
-        val grid = screen
-        if (grid.isEmpty() || rows <= 0) return false
-        if (grid.getOrNull(cursorRow) == null) return false
-        val lineRows = logicalLineRows(grid)
-        // Clamped to the row as [screenLineToCursor] clamps: a cursor parked past the row's width
-        // would overcount what is behind it and call a continuing line complete.
-        var beforeCursor = cursorCol.coerceIn(0, grid.getOrNull(cursorRow)?.size ?: 0)
-        for (row in lineRows.first until cursorRow) beforeCursor += grid[row].size
-        var total = 0
-        for (row in lineRows) {
-            val line = grid[row]
-            var cells = line.size
-            if (row == lineRows.last) while (cells > 0 && line[cells - 1].text.isBlank()) cells--
-            total += cells
-        }
-        return total > beforeCursor
+    fun receiveMirrored(text: String) {
+        typeInput(text, guarded = false, mirror = false, mirrored = true)
     }
 
     /**
-     * Rows of the logical line the cursor sits in: soft-wrap joined, up and down from the cursor
-     * row. Capped, not merely grid-bounded: [screen] includes scrollback, and a host that never
-     * prints a newline chains wrap flags across thousands of rows — joining them would build a
-     * megabyte string on the caller's thread for a classifier that reads 512 characters of a
-     * candidate. The window keeps the rows nearest the cursor, which are the ones the shell's
-     * line actually lives on; past it the join degrades to what the old single-row read saw.
+     * Answer this pane's own sudo prompt because a synchronized pane just answered its own
+     * ([MirroredInput.SudoAnswer]). Entering one sudo password across the group is the case the
+     * toggle exists for, and the panes are separate hosts: each sends the credential it
+     * authenticated with, never the origin's.
+     *
+     * A pane whose own offer is not standing is left alone, and that is not a missed keystroke: the
+     * origin is at a sudo prompt when it takes its offer, so
+     * [app.skerry.ui.session.paneSyncTargets] has already narrowed the targets to panes that are
+     * themselves at a prompt. Sending a bare Enter here would submit an EMPTY password to that
+     * host's sudo and burn one of its three attempts — seven times over on an eight-pane group.
+     * The prompt stays on screen for its own user to answer.
      */
-    private fun logicalLineRows(grid: List<List<TermCell>>): IntRange {
-        var first = cursorRow
-        while (
-            first > 0 && cursorRow - first < MAX_JOINED_WRAP_ROWS &&
-            grid.getOrNull(first - 1)?.wrapsToNextRow() == true
-        ) first--
-        var last = cursorRow
-        while (
-            last - cursorRow < MAX_JOINED_WRAP_ROWS && last + 1 < grid.size &&
-            grid.getOrNull(last)?.wrapsToNextRow() == true
-        ) last++
-        return first..last
+    fun answerSudoPrompt() {
+        if (sendSudoPassword()) inputVersion++
     }
 
     /**
-     * Whether the current cursor row looks like a password prompt (echo is usually off there).
-     * Reads the published [screen] snapshot (UI thread, no race with the emulator) at [cursorRow],
-     * which already addresses that snapshot including scrollback. A row is treated as a
-     * prompt if it ends with ":" and contains one of the keyword hints, to avoid suppressing
-     * history on plain text like `cat passwords.txt`. Heuristic: erring toward not saving a
-     * command is safer than leaking a secret.
+     * Turning "Offer the saved password to sudo" off under a live session ends its offer and drops
+     * the password, the way [applyClipboardWriteEnabled] carries its own setting into open panes —
+     * a toggle the user reaches for because a session is behaving oddly has to take effect there.
      */
-    private fun atPasswordPrompt(): Boolean {
-        val grid = screen
-        if (grid.isEmpty() || rows <= 0) return false
-        val line = grid.getOrNull(cursorRow) ?: return false
-        val text = line.joinToString("") { it.text }.trim().lowercase()
-        if (!text.endsWith(":")) return false
-        return PASSWORD_PROMPT_HINTS.any { it in text }
+    fun applySudoOfferEnabled(enabled: Boolean) {
+        if (!enabled) sudo?.revoke()
     }
 
     /**
@@ -1068,7 +1105,7 @@ class TerminalScreenState(
      */
     private fun echoedLine(line: String): String {
         if (line.isEmpty()) return ""
-        val onScreen = screenLineToCursor()
+        val onScreen = cursorLine().toCursor()
         // Compared in place: this runs on every published snapshot, and a substring per candidate
         // length would allocate through the whole line on each batch of output.
         var length = minOf(onScreen.length, line.length)
@@ -1089,6 +1126,9 @@ class TerminalScreenState(
      */
     fun sendUserInput(text: String) {
         inputVersion++
+        // A snippet, a keybar sequence or an AI-confirmed line answering the prompt is the user
+        // entering their own secret, exactly as typing one is.
+        declineSudoOffer()
         // The engine never sees this input by itself, so it is told what the input did to the line —
         // otherwise the guard, the suggestion and the history all work off a line that was left
         // behind two commands ago. Applied here rather than posted to the emulator's queue: the next
@@ -1139,6 +1179,11 @@ class TerminalScreenState(
      */
     fun sendSharedInput(bytes: ByteArray) {
         inputVersion++
+        // A viewer of a shared session types on the same prompt the owner sees, so their keystroke
+        // ends the offer exactly as the owner's would. The hint simply goes: it is deliberately not
+        // replaced with a line explaining who withdrew it, because the owner's next Enter must
+        // commit what the viewer entered either way, and that is what the hint's absence says.
+        declineSudoOffer()
         sendBytes(bytes)
     }
 
@@ -1176,6 +1221,7 @@ class TerminalScreenState(
     /** Paste clipboard text: wraps it in markers when bracketed paste is enabled (DEC 2004). */
     fun paste(text: String, mirror: Boolean = true) {
         if (text.isEmpty()) return
+        declineSudoOffer()
         // A paste carrying a newline runs the moment it lands — on a production session it goes
         // through the same confirmation as a typed command ([TerminalCommandGuard.holdPaste]).
         // The password-prompt exemption is [typeInput]'s, for the same reason: a manager pastes the
@@ -1297,6 +1343,11 @@ class TerminalScreenState(
                     closeFailure.printStackTrace()
                 }
             } finally {
+                // The session is over (EOF, disconnect, or the pane closing with the scope): drop
+                // the saved password. The connection controller drops its own copy on a clean exit
+                // for the same reason, and a String cannot be zeroed — the least this can do is not
+                // outlive the connection it belongs to.
+                sudo?.revoke()
                 // The scope is a SupervisorJob: this coroutine dying (parser exception) does NOT
                 // take the session collector with it. Close the queue so the collector's next send
                 // fails fast instead of feeding a channel nobody drains, and return the permits of
@@ -1330,20 +1381,18 @@ class TerminalScreenState(
 }
 
 /**
- * What a synchronized pane is mirroring (see [TerminalScreenState.inputMirror]). Typing and pasting
- * stay apart because the receiving pane has to replay each the way it would have arrived there:
- * typed input feeds its autocomplete, a paste gets that pane's own bracketed-paste wrapping.
+ * What a synchronized pane is mirroring (see [TerminalScreenState.inputMirror]). The three stay
+ * apart because the receiving pane has to replay each the way it would have arrived there: typed
+ * input feeds its autocomplete, a paste gets that pane's own bracketed-paste wrapping, and the
+ * answer to a sudo prompt is the pane's own saved password rather than the origin's bytes.
  */
-enum class MirroredInput { Typed, Pasted }
+enum class MirroredInput { Typed, Pasted, SudoAnswer }
 
 /**
  * Process start mark: the default monotonic clock behind [TerminalScreenState]'s search refresh
  * throttle and its publish-rate cap.
  */
 private val STARTED_AT = TimeSource.Monotonic.markNow()
-
-/** How many soft-wrapped rows [TerminalScreenState.logicalLineRows] joins in each direction. */
-private const val MAX_JOINED_WRAP_ROWS = 64
 
 /**
  * How many PTY chunks may sit unapplied between the session collector and the emulator before the
@@ -1372,6 +1421,9 @@ internal const val FEED_BACKLOG_CHUNKS = 64
  * grows the worst-case scheduling delay of the outbound writer on a saturated pool with it.
  */
 internal const val PUBLISH_MIN_INTERVAL_MS = 16L
+
+/** Numpad Enter in application-keypad mode (DECKPAM), as `keypadSequence` in TerminalInput.kt sends it. */
+private const val NUMPAD_ENTER_SS3 = "\u001bOM"
 
 /**
  * The emulator owner loop: applies commands strictly in order and publishes snapshots at a
@@ -1519,17 +1571,6 @@ private sealed interface TerminalCommand {
     /** The runbook step the terminal should report, and the echo of its probes to hide. */
     class ExpectStep(val token: String?, val hiddenEcho: List<String>) : TerminalCommand
 }
-
-/**
- * Prompt-line keywords that mark input as secret and exempt it from history (see
- * [TerminalScreenState.atPasswordPrompt]). Covers typical sudo/ssh/passwd/su prompts and the common
- * MFA wordings: with synchronized panes a missed prompt mirrors the secret into every other pane of
- * the tab, so the list errs wide — a false match only keeps an ordinary command out of history.
- */
-private val PASSWORD_PROMPT_HINTS = listOf(
-    "password", "passphrase", "passcode", "verification code", "pin",
-    "otp", "one-time", "token", "2fa", "mfa", "authenticator", "challenge",
-)
 
 /**
  * Extract the last command and its output from flat screen [text] (rows joined by '\n', trailing

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
@@ -63,7 +63,14 @@ fun tearDownForLock(
     // Guarded per pane, not per step: each pane holds its own decrypted credential, so one that
     // refuses to let go must not leave the panes after it holding theirs behind a locked vault.
     sessions?.tabs?.forEach { tab ->
-        tab.panes.forEach { pane -> failures.run { pane.controller.clearReconnectCredentials() } }
+        tab.panes.forEach { pane ->
+            failures.run { pane.controller.clearReconnectCredentials() }
+            // The same credential again: a pane's terminal holds its own copy to offer back at a
+            // sudo prompt (issue #360), and it must not survive the lock the reconnect copy is
+            // dropped for. Also ends any offer standing when the screen locked, so unlocking does
+            // not resume one the user never re-consented to.
+            failures.run { pane.liveTerminal?.applySudoOfferEnabled(false) }
+        }
     }
     failures.run { sync?.pauseForLock() }
     failures.run { snippets?.dismissRun() }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopSettingsStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopSettingsStateTest.kt
@@ -233,6 +233,19 @@ class DesktopSettingsStateTest {
         assertEquals(true, s.showTerminalTitleOnTabs)
     }
 
+    /** Issue #360. Off by default on both platforms: a heuristic holding a secret is opt-in. */
+    @Test
+    fun toggleOfferSudoPassword_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = DesktopSettingsState(onOfferSudoPasswordChange = { seen += it })
+        assertEquals(false, s.offerSudoPassword)
+        s.toggleOfferSudoPassword()
+        assertEquals(true, s.offerSudoPassword)
+        s.toggleOfferSudoPassword()
+        assertEquals(false, s.offerSudoPassword)
+        assertEquals(listOf(true, false), seen)
+    }
+
     @Test
     fun setTerminalScrollback_updates_and_reports_skipping_repeat_and_out_of_range() {
         val seen = mutableListOf<Int>()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
@@ -104,6 +104,18 @@ class MobileDesignStateTest {
     }
 
     @Test
+    fun toggleOfferSudoPassword_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = MobileDesignState(onOfferSudoPasswordChange = { seen += it })
+        assertEquals(false, s.offerSudoPassword) // off by default (issue #360): a heuristic holds a secret
+        s.toggleOfferSudoPassword()
+        assertEquals(true, s.offerSudoPassword)
+        s.toggleOfferSudoPassword()
+        assertEquals(false, s.offerSudoPassword)
+        assertEquals(listOf(true, false), seen)
+    }
+
+    @Test
     fun toggleConfirmProductionWarnings_flips_and_reports() {
         val seen = mutableListOf<Boolean>()
         val s = MobileDesignState(onConfirmProductionWarningsChange = { seen += it })

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestFixtures.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestFixtures.kt
@@ -129,6 +129,9 @@ internal class FakeSshConnection(
 internal class FakeShellChannel : ShellChannel {
     private val emissions = Channel<ByteArray>(Channel.UNLIMITED)
     private var eof = false
+
+    /** What the session sent, decoded — the only way to tell one answer to a prompt from another. */
+    val written = mutableListOf<String>()
     override val isOpen: Boolean = true
     override val endedWithEof: Boolean get() = eof
     override val output: Flow<ByteArray> = flow { for (chunk in emissions) emit(chunk) }
@@ -143,7 +146,9 @@ internal class FakeShellChannel : ShellChannel {
         emissions.close()
     }
 
-    override suspend fun write(data: ByteArray) {}
+    override suspend fun write(data: ByteArray) {
+        written += data.decodeToString()
+    }
     override suspend fun resize(size: PtySize) {}
     /** Server/transport-side drop: the channel ends WITHOUT EOF (reconnect candidate). */
     override suspend fun close() {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/HostConnectTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/HostConnectTest.kt
@@ -8,8 +8,14 @@ import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
+import app.skerry.ui.terminal.PromptRow
+import app.skerry.ui.terminal.OFFER_DWELL_MS
+import app.skerry.ui.terminal.SudoPasswordOffer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Pure helpers wiring a host to a session (host → address/label, keychain secret → auth
@@ -130,6 +136,63 @@ class HostConnectTest {
         val c = Credential("c5", "cert", CredentialSecret.Certificate("PEMDATA", "CERTDATA", null))
         assertEquals(SshAuth.Certificate("PEMDATA", "CERTDATA", null), c.toSshAuth())
     }
+
+    // --- The sudo offer (issue #360): what a session may hand back to a sudo prompt ---
+
+    @Test
+    fun sudo_offer_is_absent_while_the_setting_is_off() {
+        assertNull(sudoOfferFor(sshTarget("deploy"), SshAuth.Password("hunter2"), enabled = false))
+    }
+
+    @Test
+    fun sudo_offer_needs_a_password_credential() {
+        assertNull(sudoOfferFor(sshTarget("deploy"), SshAuth.PublicKey("PEMDATA", null), enabled = true))
+        assertNull(sudoOfferFor(sshTarget("deploy"), SshAuth.Password(""), enabled = true))
+    }
+
+    /** With no account name there is nothing to match a prompt against — see [SudoPasswordOffer]. */
+    @Test
+    fun sudo_offer_needs_a_username() {
+        assertNull(sudoOfferFor(sshTarget("   "), SshAuth.Password("hunter2"), enabled = true))
+    }
+
+    @Test
+    fun sudo_offer_answers_a_prompt_for_the_connected_account() {
+        val offer = sudoOfferFor(sshTarget("deploy"), SshAuth.Password("hunter2"), enabled = true)
+        assertNotNull(offer)
+        offer.observe(PromptRow(0, "[sudo] password for deploy: "), now = 0)
+        assertEquals("hunter2", offer.take(now = OFFER_DWELL_MS))
+
+        offer.observe(PromptRow(0, "[sudo] password for root: "), now = 0)
+        assertNull(offer.take(now = OFFER_DWELL_MS), "a prompt for another account was answered")
+    }
+
+    /**
+     * A container profile execs into an image once the host's SSH leg is up: the shell on screen is
+     * not the account that authenticated, and the host's password has no business in it.
+     */
+    @Test
+    fun sudo_offer_is_absent_for_a_container_profile() {
+        val target = sshTarget("deploy").copy(connectionType = ConnectionType.CONTAINER)
+        assertNull(sudoOfferFor(target, SshAuth.Password("hunter2"), enabled = true))
+    }
+
+    /** The hint has to name whose secret it is about to send — an inner ssh looks the same. */
+    @Test
+    fun sudo_offer_names_the_account_and_host() {
+        val offer = sudoOfferFor(sshTarget("deploy"), SshAuth.Password("hunter2"), enabled = true)
+        assertNotNull(offer)
+        assertEquals("deploy@10.0.0.5", offer.account)
+    }
+
+    /** The secret must not reach a log or a crash report through a stray interpolation. */
+    @Test
+    fun sudo_offer_redacts_its_password() {
+        val offer = SudoPasswordOffer("deploy", "deploy@10.0.0.5", "hunter2")
+        assertTrue("hunter2" !in offer.toString(), offer.toString())
+    }
+
+    private fun sshTarget(username: String) = SshTarget(host = "10.0.0.5", port = 22, username = username)
 
     @Test
     fun short_cipher_drops_vendor_suffix() {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -663,6 +664,53 @@ class SessionsControllerTest {
         scope.cancel()
     }
 
+    /**
+     * Issue #360: the pane that answered a sudo prompt with its saved password mirrors the *answer*,
+     * not the bytes — each pane sends its own credential to its own prompt.
+     *
+     * The sibling here has no offer of its own, which is the case that carries the risk. The
+     * mirrored answer only ever reaches panes that are themselves at a prompt
+     * ([paneSyncTargets] filters on `awaitingSecret` while the origin is taking a secret), so a
+     * bare Enter delivered here would submit an EMPTY password to that host's sudo. Nothing may
+     * reach its PTY. Routing `SudoAnswer` back to `receiveMirrored(text)` writes `\r` and fails this.
+     */
+    @Test
+    fun `a mirrored sudo answer sends nothing to a pane with no offer`() = runTest {
+        val transport = FakeTransport()
+        val (sessions, scope) = sessionsWith(transport)
+        val a = sessions.open(hostId = "host-a")
+        val paneId = sessions.addPane()!!
+        sessions.connectPane(tabId = a, paneId = paneId, hostId = "host-b")
+        val tab = sessions.active!!
+        sessions.toggleSyncInput(a)
+        val siblingPty = transport.connections.last().channels.single()
+
+        mirrorPaneInput(tab, originPaneId = a, text = "\r", kind = MirroredInput.SudoAnswer)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(emptyList(), siblingPty.written, "an empty password was submitted to the sibling's sudo")
+        scope.cancel()
+    }
+
+    /** The same fan-out still delivers ordinary typed input — the route above is narrow, not dead. */
+    @Test
+    fun `mirrored typing still reaches the tab's other panes`() = runTest {
+        val transport = FakeTransport()
+        val (sessions, scope) = sessionsWith(transport)
+        val a = sessions.open(hostId = "host-a")
+        val paneId = sessions.addPane()!!
+        sessions.connectPane(tabId = a, paneId = paneId, hostId = "host-b")
+        val tab = sessions.active!!
+        sessions.toggleSyncInput(a)
+        val siblingPty = transport.connections.last().channels.single()
+
+        mirrorPaneInput(tab, originPaneId = a, text = "id", kind = MirroredInput.Typed)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf("id"), siblingPty.written)
+        scope.cancel()
+    }
+
     @Test
     fun `connectPane refuses a remote-desktop pane`() = runTest {
         val vncTransport = FakeVncTransport()
@@ -1211,9 +1259,13 @@ private class FakeConnection : SshConnection {
     var disconnected = false
         private set
 
+    /** Every shell this connection opened, so a test can read what the pane wrote to its PTY. */
+    val channels = mutableListOf<FakeChannel>()
+
     override val isConnected: Boolean get() = !disconnected
     override suspend fun exec(command: String): ExecResult = throw UnsupportedOperationException()
-    override suspend fun openShell(size: PtySize, term: String): ShellChannel = FakeChannel()
+    override suspend fun openShell(size: PtySize, term: String): ShellChannel =
+        FakeChannel().also { channels += it }
     override suspend fun openSftp(): SftpClient = throw UnsupportedOperationException()
     override suspend fun forwardLocal(spec: LocalForwardSpec): PortForward = throw UnsupportedOperationException()
     override suspend fun forwardRemote(spec: RemoteForwardSpec): PortForward = throw UnsupportedOperationException()
@@ -1225,9 +1277,15 @@ private class FakeConnection : SshConnection {
 
 private class FakeChannel : ShellChannel {
     private val emissions = Channel<ByteArray>(Channel.UNLIMITED)
+
+    /** What the pane sent, decoded — the only way to tell "answered its own prompt" from "sent an Enter". */
+    val written = mutableListOf<String>()
+
     override val isOpen: Boolean = true
     override val output: Flow<ByteArray> = flow { for (chunk in emissions) emit(chunk) }
-    override suspend fun write(data: ByteArray) {}
+    override suspend fun write(data: ByteArray) {
+        written += data.decodeToString()
+    }
     override suspend fun resize(size: PtySize) {}
     override suspend fun close() {
         emissions.close()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/SudoPasswordOfferTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/SudoPasswordOfferTest.kt
@@ -1,0 +1,364 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.terminal.TerminalSession
+import app.skerry.shared.terminal.TerminalState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Issue #360: at a sudo prompt the session offers back the password it authenticated with, and
+ * sends it only on an explicit Enter. The rules that carry the risk are all here — nothing is sent
+ * without the offer standing, the password never reaches the screen, and one offer answers one
+ * prompt.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SudoPasswordOfferTest {
+
+    private val prompt = "[sudo] password for deploy: "
+
+    @Test
+    fun `Enter at a sudo prompt sends the saved password`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        assertTrue(state.sudoOffer, "the offer did not stand at a sudo prompt")
+
+        state.typeInput("\r")
+        assertEquals(listOf("hunter2\r"), session.text(), "Enter did not send the saved password")
+        scope.cancel()
+    }
+
+    /** Off by default: with no offer wired in, Enter is the byte the user pressed and nothing else. */
+    @Test
+    fun `without the setting Enter stays an Enter`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        assertFalse(state.sudoOffer)
+        state.typeInput("\r")
+        assertEquals(listOf("\r"), session.text())
+        scope.cancel()
+    }
+
+    /** Any other input declines the offer and is forwarded normally — the user is typing their own. */
+    @Test
+    fun `typing declines the offer and the next Enter is the user's own`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.typeInput("s")
+        assertFalse(state.sudoOffer, "the offer survived input that was not Enter")
+        state.typeInput("\r")
+        assertEquals(listOf("s", "\r"), session.text(), "the saved password was sent over a typed one")
+        scope.cancel()
+    }
+
+    /** A paste answers the prompt too: an Enter after it commits what was pasted, not the secret. */
+    @Test
+    fun `a paste declines the offer`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.paste("typed-by-hand")
+        assertFalse(state.sudoOffer)
+        scope.cancel()
+    }
+
+    /** One offer answers one prompt: a second Enter is the user's, whatever the screen still shows. */
+    @Test
+    fun `the offer is spent by the Enter that took it`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.typeInput("\r")
+        assertFalse(state.sudoOffer, "the offer stood after it was taken")
+        state.typeInput("\r")
+        assertEquals(listOf("hunter2\r", "\r"), session.text(), "the password was sent twice")
+        scope.cancel()
+    }
+
+    /** A fresh prompt is a fresh offer: sudo re-asking after a wrong password can be answered again. */
+    @Test
+    fun `the offer re-arms on the next prompt`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.typeInput("s")
+        assertFalse(state.sudoOffer)
+        session.emit("\r\nSorry, try again.\r\n$prompt".encodeToByteArray())
+        assertTrue(state.sudoOffer, "the second prompt got no offer")
+        scope.cancel()
+    }
+
+    /** An ordinary shell line is not a prompt: Enter runs the command. */
+    @Test
+    fun `no offer stands outside a sudo prompt`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit("deploy@web:~$ uptime".encodeToByteArray())
+        assertFalse(state.sudoOffer)
+        state.typeInput("\r")
+        assertEquals(listOf("\r"), session.text())
+        scope.cancel()
+    }
+
+    /**
+     * The password is answered to the pane it was offered in. What crosses to a synchronized pane is
+     * the fact that the prompt was answered, never the secret: the pane beside this one is another
+     * host, and it answers its own prompt with its own credential.
+     */
+    @Test
+    fun `the taken password is not mirrored to synchronized panes`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+        val mirrored = mutableListOf<Pair<String, MirroredInput>>()
+        state.inputMirror = { text, kind -> mirrored += text to kind }
+
+        session.emit(prompt.encodeToByteArray())
+        state.typeInput("\r")
+
+        assertEquals(listOf("\r" to MirroredInput.SudoAnswer), mirrored, "the mirror carried the secret")
+        scope.cancel()
+    }
+
+    /**
+     * The attack the dwell exists for: a process on the host prints a prompt in the instant before
+     * an Enter the user was already going to press, to harvest it. That Enter is the user's own.
+     */
+    @Test
+    fun `a prompt drawn under the keystroke is not answered`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = eagerPublishClock())
+
+        session.emit(prompt.encodeToByteArray())
+        assertTrue(state.sudoOffer, "the offer did not arm")
+        state.typeInput("\r")
+
+        assertEquals(listOf("\r"), session.text(), "a prompt with no dwell behind it took the password")
+        scope.cancel()
+    }
+
+    /** A fullscreen TUI paints whatever it likes; an Enter there edits a buffer, it answers nothing. */
+    @Test
+    fun `no offer stands on the alternate screen`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit("\u001b[?1049h$prompt".encodeToByteArray())
+        assertFalse(state.sudoOffer, "a line inside a TUI armed the offer")
+        state.typeInput("\r")
+        assertEquals(listOf("\r"), session.text())
+        scope.cancel()
+    }
+
+    /**
+     * An Enter typed in a synchronized pane is aimed at that pane's screen: the user read its prompt,
+     * not this one's. It declines here rather than spending this host's credential.
+     */
+    @Test
+    fun `input mirrored from another pane never takes the offer`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.receiveMirrored("\r")
+
+        assertEquals(listOf("\r"), session.text(), "a mirrored Enter sent this host's password")
+        scope.cancel()
+    }
+
+    /**
+     * The other half of synchronized input: the origin pane answered its own prompt, so this one
+     * answers its own — with the password it authenticated with, not the origin's.
+     */
+    @Test
+    fun `a mirrored answer sends this pane's own password`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.answerSudoPrompt()
+
+        assertEquals(listOf("hunter2\r"), session.text())
+        scope.cancel()
+    }
+
+    /**
+     * A pane with no offer standing is left alone. The mirrored answer reaches only panes that are
+     * themselves at a prompt — `paneSyncTargets` filters on `awaitingSecret` while the origin is
+     * taking a secret — so a bare Enter here would submit an EMPTY password to that host's sudo and
+     * burn one of its three attempts, seven times over on an eight-pane group.
+     */
+    @Test
+    fun `a mirrored answer at a prompt of its own without an offer sends nothing`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        // A prompt for another account: this pane is at a password prompt, but not one its own
+        // credential answers.
+        session.emit("[sudo] password for root: ".encodeToByteArray())
+        assertFalse(state.sudoOffer, "the offer armed on another account's prompt")
+        state.answerSudoPrompt()
+
+        assertEquals(emptyList(), session.text(), "an empty password was submitted to sudo")
+        scope.cancel()
+    }
+
+    /** Turning the setting off under a live session ends the offer there and then. */
+    @Test
+    fun `turning the setting off disarms an open session`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.applySudoOfferEnabled(false)
+        assertFalse(state.sudoOffer, "the offer survived the setting being turned off")
+
+        state.typeInput("\r")
+        assertEquals(listOf("\r"), session.text(), "a revoked offer still sent the password")
+        scope.cancel()
+    }
+
+    /** A snippet or keybar sequence answering the prompt is the user entering their own secret. */
+    @Test
+    fun `sent user input declines the offer`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.sendUserInput("from-a-snippet")
+        assertFalse(state.sudoOffer)
+        state.typeInput("\r")
+
+        assertEquals(listOf("from-a-snippet", "\r"), session.text())
+        scope.cancel()
+    }
+
+    /** A viewer of a shared session types on the same prompt: their keystroke ends the offer too. */
+    @Test
+    fun `a shared-session viewer's keystroke declines the offer`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.sendSharedInput("v".encodeToByteArray())
+        assertFalse(state.sudoOffer)
+        state.typeInput("\r")
+
+        assertEquals(listOf("v", "\r"), session.text(), "the viewer's password was completed by ours")
+        scope.cancel()
+    }
+
+    /**
+     * The same rule for ordinary mirrored typing, not just Enter: a synced `ls\n` typed in another
+     * pane must not answer this one's prompt while it happens to be sitting at one.
+     */
+    @Test
+    fun `mirrored typing never takes the offer either`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.receiveMirrored("ls\n")
+
+        assertEquals(listOf("ls\n"), session.text(), "mirrored typing sent this host's password")
+        scope.cancel()
+    }
+
+    /**
+     * A TUI can exit leaving application-keypad mode set. The hint names Enter, so the numpad's
+     * Enter has to answer it — otherwise the key the user pressed spends the offer on an empty
+     * password instead of taking it.
+     */
+    @Test
+    fun `the numpad Enter answers the offer under DECKPAM`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        state.typeInput("\u001bOM")
+
+        assertEquals(listOf("hunter2\r"), session.text(), "the numpad Enter burned the offer")
+        scope.cancel()
+    }
+
+    /** The credential does not outlive its connection: the session ending drops it. */
+    @Test
+    fun `a closed session drops the password`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSudoSession()
+        val state = TerminalScreenState(session, scope, sudo = offer(), nowMillis = dwellingClock())
+
+        session.emit(prompt.encodeToByteArray())
+        assertTrue(state.sudoOffer)
+        session.close()
+
+        assertFalse(state.sudoOffer, "the offer survived the session it belongs to")
+        scope.cancel()
+    }
+
+    private fun offer() = SudoPasswordOffer("deploy", "deploy@web", "hunter2")
+}
+
+private class FakeSudoSession : TerminalSession {
+    private val _state = MutableStateFlow<TerminalState>(TerminalState.Open)
+    override val state: StateFlow<TerminalState> = _state
+
+    private val emissions = Channel<ByteArray>(Channel.UNLIMITED)
+    override val output: Flow<ByteArray> = flow { for (chunk in emissions) emit(chunk) }
+
+    private val sent = mutableListOf<ByteArray>()
+
+    fun text(): List<String> = sent.map { it.decodeToString() }
+
+    suspend fun emit(chunk: ByteArray) = emissions.send(chunk)
+
+    override suspend fun send(data: ByteArray) {
+        sent += data
+    }
+
+    override suspend fun resize(size: PtySize) {}
+
+    override suspend fun close() {
+        _state.value = TerminalState.Closed()
+        emissions.close()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TestClocks.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TestClocks.kt
@@ -17,3 +17,13 @@ internal fun eagerPublishClock(): () -> Long {
     var t = 0L
     return { t += PUBLISH_MIN_INTERVAL_MS; t }
 }
+
+/**
+ * [eagerPublishClock] with a longer step: every read also advances past [OFFER_DWELL_MS], so a sudo
+ * prompt drawn by one emit has been standing long enough by the next keystroke for the offer to be
+ * takeable. Tests about the dwell itself use the plain eager clock, where it never is.
+ */
+internal fun dwellingClock(): () -> Long {
+    var t = 0L
+    return { t += OFFER_DWELL_MS + PUBLISH_MIN_INTERVAL_MS; t }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/LockTeardownTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/LockTeardownTest.kt
@@ -1,6 +1,14 @@
 package app.skerry.ui.vault
 
 import app.skerry.shared.ssh.KeyboardInteractiveChallenge
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.shared.ssh.SshTarget
+import app.skerry.ui.terminal.TerminalSessionPrefs
+import app.skerry.ui.connection.ConnectionController
+import app.skerry.ui.connection.FakeShellChannel
+import app.skerry.ui.connection.FakeSshConnection
+import app.skerry.ui.connection.FakeSshTransport
+import app.skerry.ui.session.SessionsController
 import app.skerry.shared.ssh.KeyboardInteractivePrompt
 import app.skerry.shared.trust.HostTrustKind
 import app.skerry.shared.trust.HostTrustRequest
@@ -19,6 +27,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlin.test.Test
@@ -119,5 +128,48 @@ class LockTeardownTest {
             closeSyncSetup = { closed = true },
         )
         assertTrue(closed, "the modal survives the lock and would reopen with its question already answered")
+    }
+
+    /**
+     * Issue #360: the lock has to take the pane's saved sudo password with it. The offer is armed
+     * from a live session and the lock deliberately leaves that session open, so nothing below the
+     * terminal can drop it — `tearDownForLock` reaches every pane's terminal itself. Delete that
+     * call and this is the only test that notices.
+     */
+    @Test
+    fun `locking drops a pane's saved sudo password`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val channel = FakeShellChannel()
+        val sessions = SessionsController(
+            newId = { "s0" },
+            controllerFactory = {
+                ConnectionController(
+                    transport = FakeSshTransport(FakeSshConnection(channel)),
+                    scope = scope,
+                    newSessionScope = { CoroutineScope(UnconfinedTestDispatcher(testScheduler)) },
+                    terminalPrefs = { TerminalSessionPrefs(sudoPasswordEnabled = true) },
+                )
+            },
+        )
+        sessions.open(
+            hostId = "h",
+            title = "web",
+            subtitle = "deploy@web:22",
+            target = SshTarget(host = "web", port = 22, username = "deploy"),
+            auth = SshAuth.Password("hunter2"),
+        )
+        advanceUntilIdle()
+        val terminal = sessions.active!!.focusedPane.liveTerminal!!
+        channel.emit("[sudo] password for deploy: ".encodeToByteArray())
+        advanceUntilIdle()
+        assertTrue(terminal.sudoOffer, "the offer did not arm before the lock")
+
+        tearDownForLock(tunnels = null, sessions = sessions, sync = null, snippets = null)
+
+        assertFalse(terminal.sudoOffer, "the offer survived the vault lock")
+        terminal.typeInput("\r")
+        advanceUntilIdle()
+        assertEquals(listOf("\r"), channel.written, "the saved password survived the vault lock")
+        scope.cancel()
     }
 }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -667,6 +667,8 @@ fun main(args: Array<String>) {
                             onHostClickConnectModeChange = { prefs.set("host_click_connect", it.id) },
                             initialAllowServerClipboardWrite = prefs.bool("terminal_clipboard_write", false),
                             onAllowServerClipboardWriteChange = { prefs.set("terminal_clipboard_write", it) },
+                            initialOfferSudoPassword = prefs.bool("terminal_sudo_password", false),
+                            onOfferSudoPasswordChange = { prefs.set("terminal_sudo_password", it) },
                             initialReportTeamSessions = prefs.bool("teams_report_sessions", true),
                             onReportTeamSessionsChange = { prefs.set("teams_report_sessions", it) },
                             initialOpenFilePathsInSftp = prefs.bool("terminal_open_paths", true),

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/SudoPrompt.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/SudoPrompt.kt
@@ -1,0 +1,182 @@
+package app.skerry.shared.terminal
+
+/** Longest row a prompt is looked for in. A prompt lives at the head of the line, not past it. */
+private const val MAX_PROMPT_LENGTH = 512
+
+/** The marker every sudo build and every translation keeps verbatim. */
+private const val SUDO_MARKER = "[sudo]"
+
+/** The full-width colon the CJK translations end their prompt on, beside the ASCII one. */
+private const val FULLWIDTH_COLON = '：'
+
+/**
+ * Whether the character puts no ink on the screen — it either takes a cell and draws nothing in it
+ * or joins the cell before it.
+ *
+ * Judged by what is drawn, not by one Unicode category, because a row is hidden from the predicates
+ * below by anything the eye cannot see:
+ *
+ * * `Cf` is the obvious set — zero-width space, word joiner, BOM, soft hyphen, the bidi marks;
+ * * a variation selector is `Mn`, and [CharMetrics.isCombining] covers it, so the emulator folds it
+ *   into the *base* cell: the colon's cell becomes two characters and the row no longer ends on `:`;
+ * * the tag characters (U+E0020..U+E007F) and the variation selectors supplement are astral, so the
+ *   row ends on a low surrogate whose category is `SURROGATE` and not `FORMAT`;
+ * * U+2800 and the Hangul fillers are an ordinary symbol and ordinary letters that every font draws
+ *   as empty — nothing about their category says so.
+ */
+private fun Char.isInkless(): Boolean = when (category) {
+    CharCategory.FORMAT,
+    CharCategory.NON_SPACING_MARK,
+    CharCategory.ENCLOSING_MARK,
+    CharCategory.SURROGATE,
+    CharCategory.CONTROL,
+    CharCategory.UNASSIGNED,
+    -> true
+
+    else -> this == '\u2800' ||                                    // braille pattern blank
+        this == '\u115F' || this == '\u1160' ||                    // Hangul choseong/jungseong filler
+        this == '\u3164' || this == '\uFFA0'                       // Hangul filler, and its halfwidth form
+}
+
+/**
+ * The row as the eye reads it: trailing blanks gone, and with them the characters that take a cell
+ * without drawing in it.
+ *
+ * `trim()` alone is not enough. Kotlin trims `Char.isWhitespace()`, which is the separators plus the
+ * ASCII controls; everything [isInkless] names survives it. One such character appended after the
+ * colon leaves a row pixel-identical to a real prompt whose last character is no longer `:`, and
+ * both predicates below then read it as ordinary output — for [isPasswordPrompt] that means the
+ * password typed there is committed to the vault-backed command history and mirrored into panes at
+ * an ordinary shell.
+ *
+ * Stripped at the ends only. Inside the row an invisible character is a real difference:
+ * `deploy` followed by a zero-width space and `admin` is not the account `deploy`, and
+ * [isNameBoundary] refuses it on purpose.
+ */
+private fun String.trimInvisible(): String = trim { it.isWhitespace() || it.isInkless() }
+
+/**
+ * Where the sudo marker starts on [text], or -1 — folded one way for both predicates.
+ *
+ * They used to fold it separately, `indexOf(ignoreCase = true)` here and `lowercase()` there, and
+ * those two do not agree on every character: U+017F ſ uppercases to `S` but lowercases to itself, so
+ * `[ſudo] deploy:` armed the offer on a row the history filter called ordinary text — the one row
+ * where a declined offer is followed by a hand-typed password.
+ */
+private fun sudoMarkerAt(text: String): Int = text.indexOf(SUDO_MARKER, ignoreCase = true)
+
+/**
+ * What separates an account name from the words around it in a prompt. Everything else counts as
+ * part of the name, non-ASCII included: `-` is a legal name character, so `deploy` must not answer
+ * the prompt naming `deploy-admin`, and a look-alike separator (U+2011 for the hyphen, a zero-width
+ * space) must not turn that same row back into a match. Unknown characters therefore join the name
+ * and the offer is refused — the direction a heuristic guarding a secret has to fail in.
+ */
+private fun Char.isNameBoundary(): Boolean =
+    isWhitespace() || this == FULLWIDTH_COLON || this in ",.:;!?'\"`()[]{}<>|/\\"
+
+/**
+ * Whether [line] — one terminal row, as drawn — is sudo asking [username] for their password.
+ *
+ * Three facts have to hold together, and each one carries a share of the risk:
+ *
+ * * the literal `[sudo]` is on the row. It is the one part of the prompt no locale translates
+ *   (`[sudo] пароль для %p:`, `[sudo] %p 的密码：`), which is why the marker is the anchor and the
+ *   word "password" is not — matching on that would fire on ssh's prompt, su's, and any program
+ *   that asks for one;
+ * * the row ends on a colon, ASCII or full-width. A prompt that has been answered has the shell's
+ *   next line after it and no longer ends there;
+ * * [username] appears on the row as a whole name. `rootpw` and `targetpw` make sudo ask for
+ *   *another* account's password and say so in the prompt — this session's credential is not that
+ *   account's, and offering it would send the wrong secret to a program that asks for a right one.
+ *
+ * A row carrying a bidi override or isolate is refused outright, at its ends as much as in its
+ * middle: those reorder what the user reads without changing what matches here, and the whole
+ * feature rests on the row on screen being the row that was tested.
+ *
+ * A custom `Defaults passprompt` that drops the marker is simply not recognised: the offer does not
+ * appear and the password is typed by hand, which is the safe direction for a heuristic to fail in.
+ *
+ * The caller must still require an explicit keypress before sending anything — a remote process can
+ * print whatever it likes, this row included.
+ */
+fun isSudoPasswordPrompt(line: String, username: String): Boolean {
+    val name = username.trim()
+    if (name.isEmpty()) return false
+    // Trimmed before the length is judged: a grid row is always exactly `cols` characters, blanks
+    // included, so measuring the raw string would turn every window wider than the cap into one
+    // where the offer never appears. What is capped is how much text the prompt is allowed to be.
+    val text = line.trimInvisible()
+    if (text.length > MAX_PROMPT_LENGTH) return false
+    val last = text.lastOrNull() ?: return false
+    // Cheapest discriminator first: almost no row of ordinary output ends on a colon, so the
+    // full-row scan below runs on the few that could be prompts rather than on every line drawn.
+    if (last != ':' && last != FULLWIDTH_COLON) return false
+    // Scanned on the row as handed in, not on `text`: the trim removes exactly what this refuses —
+    // the overrides and isolates are format characters too — so scanning the trimmed string would
+    // let an override at either end through the guard this line is.
+    if (line.any { !isSafeDisplayChar(it) }) return false
+    // Case-insensitive on the marker only: an account name is case-sensitive on Unix, and folding
+    // it would let a prompt for `Deploy` answer for `deploy`.
+    val marker = sudoMarkerAt(text)
+    if (marker < 0) return false
+    return namesUser(text, marker + SUDO_MARKER.length, name)
+}
+
+/** Whether [name] occurs in [text] at or after [from] as a whole account name. */
+private fun namesUser(text: String, from: Int, name: String): Boolean {
+    var at = text.indexOf(name, from)
+    while (at >= 0) {
+        val before = text.getOrNull(at - 1)
+        val after = text.getOrNull(at + name.length)
+        if (before?.isNameBoundary() != false && after?.isNameBoundary() != false) return true
+        at = text.indexOf(name, at + 1)
+    }
+    return false
+}
+
+/**
+ * Whether [line] — the cursor row, as drawn — reads as any program's password prompt.
+ *
+ * Broader and blunter than [isSudoPasswordPrompt] on purpose: this one decides that what is typed
+ * next must be kept out of command history, out of the production-guard dialog and out of a
+ * synchronized pane sitting at an ordinary shell. Over-matching costs a command its history entry;
+ * under-matching writes a secret to disk, so `cat passwords.txt` losing its history entry is the
+ * trade this makes.
+ *
+ * The keyword list is multilingual for a concrete reason: sudo is translated, and a user who
+ * declines the saved-password offer at `[sudo] пароль для deploy:` types the secret by hand. If
+ * only the English words were known, that row would not read as a prompt and the password would be
+ * tracked as a command.
+ */
+fun isPasswordPrompt(line: String): Boolean {
+    // Deliberately NOT capped by [MAX_PROMPT_LENGTH]. There, refusing a long row means "do not offer
+    // the password", which is safe; here it would mean "this is not a secret, track it as a command".
+    // A terminal wider than the cap, or a host padding the row with invisible combining characters,
+    // would then put a hand-typed password into the vault-backed history and mirror it into every
+    // synchronized pane. The scan is bounded by the row's own width either way.
+    val text = line.trimInvisible()
+    val last = text.lastOrNull() ?: return false
+    if (last != ':' && last != FULLWIDTH_COLON) return false
+    // sudo's own marker counts as a hint of its own, so this can never fail to recognise a row the
+    // offer recognised. sudo is translated into more locales than any keyword list will hold
+    // (`[sudo] парола за deploy:`, `[sudo] geslo za deploy:`), and the row where the two could
+    // disagree is exactly the one where a declined offer is followed by a hand-typed password.
+    if (sudoMarkerAt(text) >= 0) return true
+    val folded = text.lowercase()
+    return PASSWORD_PROMPT_HINTS.any { it in folded }
+}
+
+/**
+ * Words that make a row ending in a colon a password prompt. English first (the overwhelming
+ * default for a server locale), then the translations sudo, ssh, su and polkit ship — the languages
+ * whose prompt a user of this client is realistically sitting in front of.
+ */
+private val PASSWORD_PROMPT_HINTS = listOf(
+    "password", "passphrase", "passcode", "verification code", "pin",
+    "otp", "one-time", "token", "2fa", "mfa", "authenticator", "challenge",
+    "пароль", "passwort", "mot de passe", "contraseña", "senha", "wachtwoord",
+    "hasło", "lösenord", "salasana", "adgangskode", "passord", "heslo", "jelszó",
+    "parolă", "şifre", "密码", "密碼", "パスワード", "암호", "비밀번호", "كلمة المرور",
+    "парола", "geslo", "lozinka", "mật khẩu", "κωδικός", "lykilorð", "slaptažodis", "parole",
+)

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/SudoPromptTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/SudoPromptTest.kt
@@ -1,0 +1,233 @@
+package app.skerry.shared.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What [isSudoPasswordPrompt] may and may not answer `true` to. The detector decides whether the
+ * client offers back the password this session authenticated with, so a false positive is the
+ * expensive direction: it puts the offer under a line that is not sudo asking this user.
+ */
+class SudoPromptTest {
+
+    @Test
+    fun `the default English prompt is recognised`() {
+        assertTrue(isSudoPasswordPrompt("[sudo] password for deploy:", "deploy"))
+        assertTrue(isSudoPasswordPrompt("[sudo] password for deploy: ", "deploy"))
+    }
+
+    /**
+     * Every translation keeps the literal `[sudo]` — only the words around it change — which is
+     * what makes the marker usable as the anchor instead of the word "password".
+     */
+    @Test
+    fun `localized prompts are recognised`() {
+        assertTrue(isSudoPasswordPrompt("[sudo] пароль для deploy:", "deploy"))
+        assertTrue(isSudoPasswordPrompt("[sudo] Passwort für deploy:", "deploy"))
+        // French puts a space before the colon.
+        assertTrue(isSudoPasswordPrompt("[sudo] Mot de passe de deploy :", "deploy"))
+        assertTrue(isSudoPasswordPrompt("[sudo] hasło użytkownika deploy:", "deploy"))
+        // Chinese ends on a full-width colon.
+        assertTrue(isSudoPasswordPrompt("[sudo] deploy 的密码：", "deploy"))
+        assertTrue(isSudoPasswordPrompt("[sudo] deploy のパスワード:", "deploy"))
+    }
+
+    /**
+     * `rootpw`/`targetpw` make sudo ask for someone else's password. The prompt names whose it
+     * wants, and this session's credential is not it.
+     */
+    @Test
+    fun `a prompt naming another user is refused`() {
+        assertFalse(isSudoPasswordPrompt("[sudo] password for root:", "deploy"))
+        assertFalse(isSudoPasswordPrompt("[sudo] password for deploy-admin:", "deploy"))
+        assertFalse(isSudoPasswordPrompt("[sudo] password for xdeploy:", "deploy"))
+    }
+
+    /** Other password prompts belong to other credentials — ssh's, su's, a program's own. */
+    @Test
+    fun `prompts that are not sudo are refused`() {
+        assertFalse(isSudoPasswordPrompt("deploy@10.0.0.5's password:", "deploy"))
+        assertFalse(isSudoPasswordPrompt("Password:", "deploy"))
+        assertFalse(isSudoPasswordPrompt("Enter passphrase for key '/home/deploy/.ssh/id_ed25519':", "deploy"))
+        assertFalse(isSudoPasswordPrompt("[sudo] password for deploy", "deploy"))
+        assertFalse(isSudoPasswordPrompt("$ sudo apt update", "deploy"))
+        assertFalse(isSudoPasswordPrompt("", "deploy"))
+    }
+
+    /** A session with no username to match against can never have a prompt addressed to it. */
+    @Test
+    fun `a blank username never matches`() {
+        assertFalse(isSudoPasswordPrompt("[sudo] password for deploy:", ""))
+        assertFalse(isSudoPasswordPrompt("[sudo] password for :", "  "))
+    }
+
+    /**
+     * A prompt sudo has already answered scrolls up and stays on screen. The marker is only read
+     * where the cursor is, but the line itself must still end at the colon — text typed after it
+     * means the prompt was answered and the shell moved on.
+     */
+    @Test
+    fun `text after the colon ends the prompt`() {
+        assertFalse(isSudoPasswordPrompt("[sudo] password for deploy: uptime", "deploy"))
+    }
+
+    /**
+     * The account-name boundary has to hold for characters that only look like separators, or the
+     * `deploy-admin` case above is reopened by a hyphen the row draws identically (U+2011) and by a
+     * zero-width space. Anything not a known separator counts as part of the name: the offer is then
+     * refused, which is the direction this is allowed to fail in.
+     */
+    @Test
+    fun `look-alike separators do not split the account name`() {
+        assertFalse(isSudoPasswordPrompt("[sudo] password for deploy\u2011admin:", "deploy"))
+        assertFalse(isSudoPasswordPrompt("[sudo] password for deploy\u200Badmin:", "deploy"))
+    }
+
+    /** A row that reorders what it draws is not the row that was matched, so it is not matched. */
+    @Test
+    fun `a row carrying bidi controls is refused`() {
+        assertFalse(isSudoPasswordPrompt("[sudo] password for \u202Eyolped:", "deploy"))
+    }
+
+    /**
+     * At the ends of the row as much as in the middle. The trim that keeps a trailing zero-width
+     * character from hiding a prompt from history removes the overrides too — they are the same
+     * Unicode category — so the offer has to judge the row it was handed, not the trimmed one.
+     * History still tracks the row as a prompt: over-matching there costs a command its entry,
+     * under-matching writes a password to disk.
+     */
+    @Test
+    fun `a bidi override at the edge of the row is refused`() {
+        assertFalse(isSudoPasswordPrompt("\u202E[sudo] password for deploy:", "deploy"))
+        assertFalse(isSudoPasswordPrompt("[sudo] password for deploy:\u202E", "deploy"))
+        assertTrue(isPasswordPrompt("[sudo] password for deploy:\u202E"))
+    }
+
+    /** The marker is sudo's, whatever case a build prints it in; the account name is Unix's. */
+    @Test
+    fun `the marker folds case and the account name does not`() {
+        assertTrue(isSudoPasswordPrompt("[SUDO] password for deploy:", "deploy"))
+        assertFalse(isSudoPasswordPrompt("[sudo] password for Deploy:", "deploy"))
+    }
+
+    /** A row longer than a prompt is output that happens to contain one, not a prompt. */
+    @Test
+    fun `an overlong row is refused`() {
+        assertFalse(isSudoPasswordPrompt("deploy@web ".repeat(60) + "[sudo] password for deploy:", "deploy"))
+    }
+
+    /**
+     * What the terminal actually hands in is a grid row: exactly as many characters as the window
+     * has columns, blanks included. Measuring that instead of the text would make every window wider
+     * than the cap one where the offer never appears.
+     */
+    @Test
+    fun `a prompt padded out to the window width is still recognised`() {
+        val row = "[sudo] password for deploy:".padEnd(700, ' ')
+        assertTrue(isSudoPasswordPrompt(row, "deploy"), "a wide window switched the offer off")
+        assertTrue(isPasswordPrompt(row))
+    }
+
+    /**
+     * [isPasswordPrompt] is the blunt one: it decides what stays out of history, out of the
+     * production guard and out of a synchronized pane. It has to know every prompt the sudo detector
+     * knows — a user who declines the offer at a translated prompt types the secret by hand, and a
+     * row this did not recognise would put it in the vault-backed history.
+     */
+    @Test
+    fun `a password prompt is recognised in the languages sudo is translated into`() {
+        assertTrue(isPasswordPrompt("[sudo] password for deploy:"))
+        assertTrue(isPasswordPrompt("[sudo] пароль для deploy:"))
+        assertTrue(isPasswordPrompt("[sudo] Passwort für deploy:"))
+        assertTrue(isPasswordPrompt("[sudo] deploy 的密码："))
+        assertTrue(isPasswordPrompt("[sudo] deploy のパスワード:"))
+        assertTrue(isPasswordPrompt("deploy@10.0.0.5's password:"))
+        assertTrue(isPasswordPrompt("Enter passphrase for key '/home/deploy/.ssh/id_ed25519':"))
+    }
+
+    /**
+     * The length cap belongs to the offer, not to this predicate. Refusing a long row here would
+     * mean "not a secret, track it as a command", so a terminal wider than the cap — or a host
+     * padding the row with invisible characters — would put a hand-typed password into the
+     * vault-backed history and mirror it into every synchronized pane.
+     */
+    @Test
+    fun `a row too long to offer on is still a password prompt`() {
+        val wide = "deploy@web ".repeat(60) + "[sudo] password for deploy:"
+        assertTrue(isPasswordPrompt(wide), "a wide terminal switched off the secret-input detection")
+        assertFalse(isSudoPasswordPrompt(wide, "deploy"), "the offer must still refuse an overlong row")
+    }
+
+    /**
+     * The blunt detector has to be a superset of the precise one, or the row where a user declines
+     * the offer and types the password by hand is the row that is not treated as a secret. sudo is
+     * translated into more locales than any keyword list holds, so the marker itself counts.
+     */
+    @Test
+    fun `every row the offer recognises is a password prompt`() {
+        val locales = listOf(
+            "[sudo] парола за deploy:",   // bg
+            "[sudo] geslo za deploy:",    // sl
+            "[sudo] lozinka za deploy:",  // hr
+            "[sudo] mật khẩu cho deploy:",
+            // U+017F uppercases to S but lowercases to itself, so a marker folded one way and
+            // matched the other way disagreed on exactly this row.
+            "[\u017Fudo] deploy:",
+        )
+        for (row in locales) {
+            assertTrue(isSudoPasswordPrompt(row, "deploy"), row)
+            assertTrue(isPasswordPrompt(row), "the offer armed on a row history does not treat as secret: $row")
+        }
+    }
+
+    /**
+     * A character that occupies a cell without drawing anything must not decide what a secret is.
+     * `trim()` removes `Char.isWhitespace()` only, and every format character (category Cf) survives
+     * it — one appended after the colon leaves a row pixel-identical to a real prompt whose last
+     * character is no longer ':'. Read as ordinary output, the password typed there is committed to
+     * the vault-backed command history and mirrored into panes at an ordinary shell.
+     */
+    @Test
+    fun `a trailing invisible character does not hide a password prompt`() {
+        val invisible = listOf('\u200B', '\u200E', '\u2060', '\uFEFF', '\u00AD')
+        for (c in invisible) {
+            val row = "[sudo] password for deploy:" + c
+            val at = c.code.toString(16)
+            assertTrue(isPasswordPrompt(row), "history stopped seeing a prompt ending in U+$at")
+            assertTrue(isSudoPasswordPrompt(row, "deploy"), "the offer stopped seeing U+$at")
+        }
+    }
+
+    /**
+     * Category Cf is not the whole of what draws nothing. A variation selector is a non-spacing
+     * mark and the emulator folds it into the colon's own cell; a tag character is an astral
+     * codepoint, so the row ends on a surrogate and its category is neither; U+2800 and the Hangul
+     * fillers are an ordinary symbol and ordinary letters that every font draws as empty. Each one
+     * appended after the colon leaves a row the user cannot tell from the prompt, and the row still
+     * has to read as a prompt to both predicates.
+     */
+    @Test
+    fun `a trailing inkless character does not hide a password prompt`() {
+        val inkless = listOf(
+            "\uFE0E",        // variation selector-15, folded into the base cell
+            "\uDB40\uDC20",  // U+E0020 tag space, an astral format character
+            "\u2800",        // braille pattern blank
+            "\u3164",        // Hangul filler
+        )
+        for (c in inkless) {
+            val row = "[sudo] password for deploy:" + c
+            val at = c.map { it.code.toString(16) }.joinToString("+")
+            assertTrue(isPasswordPrompt(row), "history stopped seeing a prompt ending in U+$at")
+            assertTrue(isSudoPasswordPrompt(row, "deploy"), "the offer stopped seeing U+$at")
+        }
+    }
+
+    /** Ordinary output must still reach history: over-matching costs every command on the row. */
+    @Test
+    fun `an ordinary line is not a password prompt`() {
+        assertFalse(isPasswordPrompt("deploy@web:~$ cat passwords.txt"))
+        assertFalse(isPasswordPrompt("total 48"))
+        assertFalse(isPasswordPrompt(""))
+    }
+}


### PR DESCRIPTION
## What this does

A `sudo` prompt asking the account the SSH session authenticated with now gets a hint above the
terminal: **Enter** sends the password the connection already holds. Any other key declines the offer
and is forwarded to the host as ordinary input.

The password is never drawn on screen, never enters command history, never reaches a session
recording, and is never shown by the production-guard dialog. It is held only for the life of the
session and dropped when the vault locks, when the session closes, or when the setting is turned off.

Off by default, behind **Settings → Terminal → "Offer the saved password to sudo"**. The Enter binding
is listed in **Settings → Keyboard**. Desktop and Android share the whole path; strings are in
en / ru / zh.

## How the prompt is recognised

Three facts have to hold together:

- the literal `[sudo]` is on the row — the one part of the prompt no locale translates, which is why
  the marker is the anchor and the word "password" is not;
- the row ends on a colon, ASCII or full-width;
- the account name appears on the row as a whole name, so a prompt made by `rootpw` or `targetpw` for
  *another* account is never answered with this session's credential.

A row carrying a bidi override or isolate is refused outright, at its ends as much as in its middle,
and a row padded with characters that draw no ink — format characters, variation selectors folded
into the base cell, astral tag characters, the blank-drawing letters — is read as the eye reads it.
Neither can hide a prompt from the broader guard that keeps a hand-typed password out of the
vault-backed command history.

A custom `Defaults passprompt` that drops the marker is simply not recognised: the offer does not
appear and the password is typed by hand.

## Synchronized panes

In a group of synchronized panes each pane answers its own prompt with its own credential. The
mirrored Enter carries no bytes, so a pane with no offer standing sends nothing rather than an empty
password.

## Verifying it

1. Settings → Terminal, turn on "Offer the saved password to sudo".
2. Connect to a host with a saved password credential and run `sudo -k; sudo -v`.
3. The hint appears above the terminal naming the account. Press **Enter** — sudo authenticates and
   nothing is echoed.
4. Repeat and type any other key instead: the hint disappears and the key reaches the shell.
5. Open Settings → Vault and lock it while a hint stands — the hint goes and Enter is an ordinary
   Enter again.
6. Command history (Ctrl+R) holds no entry for either attempt.

Fixes #360
