### PR TITLE
feat(android): keep a session alive through Doze and OEM task killers

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -21,6 +21,26 @@
     <!-- Notification for the keep-alive service. Optional: without it the service still runs, the
          notification is simply not shown. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Partial wake lock while a session is open, and only when the user turns it on in
+         More -> Background & lock screen. Being a foreground service keeps the process, not the
+         CPU: with the screen off the device suspends between wakeups and the SSH keepalive misses
+         its interval. Off by default; the app works without it, the session just may not survive
+         a locked screen. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <!-- The ROM settings apps whose autostart page the keep-alive screen offers to open. Declared
+         so that getApplicationInfo can answer whether the package is a system one: under Android 11
+         package visibility an undeclared package reads as "not installed", and the check that keeps
+         us from handing the intent to a sideloaded impostor would refuse every real device. -->
+    <queries>
+        <package android:name="com.miui.securitycenter" />
+        <package android:name="com.huawei.systemmanager" />
+        <package android:name="com.hihonor.systemmanager" />
+        <package android:name="com.coloros.safecenter" />
+        <package android:name="com.oplus.safecenter" />
+        <package android:name="com.iqoo.secure" />
+        <package android:name="com.vivo.permissionmanager" />
+    </queries>
 
     <application
         android:allowBackup="false"

--- a/androidApp/src/main/kotlin/app/skerry/android/AndroidKeepAlivePower.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/AndroidKeepAlivePower.kt
@@ -1,0 +1,161 @@
+package app.skerry.android
+
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+import android.util.Log
+import app.skerry.ui.keepalive.KeepAlivePower
+import app.skerry.ui.keepalive.KeepAliveVendor
+import app.skerry.ui.keepalive.keepAliveVendorOf
+
+/**
+ * Android side of [KeepAlivePower]: the stored wake-lock preference plus the system pages a person
+ * has to visit for a session to survive the screen going off.
+ *
+ * The preference is device-local ([KeepAliveWakeLockSetting]) rather than a vault record, because it
+ * describes this phone's power behaviour — carrying it to a desktop or another phone would mean
+ * nothing. [SessionKeepAliveService] reads the same store when a session opens; a switch flipped
+ * while sessions are already running is pushed to the service so it takes effect now.
+ *
+ * Nothing here throws: an intent that no activity answers, or that the system refuses, falls back to
+ * this app's own details page, which exists on every device.
+ */
+internal class AndroidKeepAlivePower(
+    private val context: Context,
+    /** Whether a session is open right now; a switch flipped in between must reach the live service. */
+    private val hasLiveSessions: () -> Boolean,
+) : KeepAlivePower {
+
+    override val manufacturer: String = Build.MANUFACTURER.orEmpty()
+
+    override val vendor: KeepAliveVendor = keepAliveVendorOf(manufacturer)
+
+    override val wakeLockEnabled: Boolean
+        get() = KeepAliveWakeLockSetting.isEnabled(context)
+
+    override fun setWakeLockEnabled(enabled: Boolean): Boolean {
+        KeepAliveWakeLockSetting.set(context, enabled)
+        if (!hasLiveSessions()) return true
+        // The service owns the lock. Without this the switch would only be honoured by the next
+        // connect, while the screen already showed it as on.
+        val intent = Intent(context, SessionKeepAliveService::class.java)
+            .setAction(SessionKeepAliveService.ACTION_SYNC_WAKE_LOCK)
+        return try {
+            context.startService(intent)
+            true
+        } catch (e: IllegalStateException) { // background start restrictions
+            Log.w(TAG, "wake-lock change not delivered to the service", e)
+            false
+        } catch (e: SecurityException) {
+            Log.w(TAG, "wake-lock change not delivered to the service", e)
+            false
+        }
+    }
+
+    override fun isExemptFromBatteryOptimization(): Boolean {
+        val power = context.getSystemService(PowerManager::class.java) ?: return false
+        return power.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    /**
+     * The system list of battery-optimised apps, not the one-tap
+     * `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` dialog: that intent needs the restricted
+     * `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission, which Google Play gates behind a
+     * declaration form, and without the permission the dialog closes without asking anything.
+     * The row's text walks through the extra taps the list costs.
+     */
+    override fun openBatteryOptimizationSettings() {
+        if (!launch(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))) openAppDetailsSettings()
+    }
+
+    /**
+     * The ROM's autostart list. Each family has moved the activity between releases, so the known
+     * ones are tried in order; when none of them opens — an unknown release, a ROM without the app —
+     * the app's own details page opens instead, which is the closest thing every device has.
+     */
+    override fun openAutostartSettings() {
+        if (autostartPages().none { launchSystemComponent(it) }) openAppDetailsSettings()
+    }
+
+    override fun openAppDetailsSettings() {
+        launch(
+            Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", context.packageName, null),
+            ),
+        )
+    }
+
+    private fun autostartPages(): List<ComponentName> =
+        KeepAliveAutostartPages.forVendor(vendor).map { (pkg, activity) -> ComponentName(pkg, activity) }
+
+    /**
+     * Opens a component of another app only where the system itself installed that app.
+     *
+     * A package name is unique on a device, but only among the packages actually installed: on a
+     * phone whose ROM app is missing, any sideloaded app is free to call itself
+     * `com.miui.securitycenter` and receive this intent. Nothing secret travels in it, but a page
+     * that claims to be the system's background settings is worth not handing to an unknown app.
+     * The packages are listed in the manifest's `<queries>`, without which Android 11+ answers
+     * "not installed" for every one of them.
+     */
+    private fun launchSystemComponent(component: ComponentName): Boolean {
+        if (!isSystemPackage(component.packageName)) return false
+        return launch(Intent().setComponent(component))
+    }
+
+    private fun isSystemPackage(packageName: String): Boolean = try {
+        val info = context.packageManager.getApplicationInfo(packageName, 0)
+        info.flags and (ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+    } catch (e: PackageManager.NameNotFoundException) {
+        Log.d(TAG, "no system package $packageName on this device", e)
+        false
+    }
+
+    private fun launch(intent: Intent): Boolean = try {
+        // Started from a settings screen, but through the application context — a task of its own.
+        context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        true
+    } catch (e: ActivityNotFoundException) {
+        Log.w(TAG, "no activity for $intent", e)
+        false
+    } catch (e: SecurityException) { // an exported-false activity of another app
+        Log.w(TAG, "refused to open $intent", e)
+        false
+    }
+
+    private companion object {
+        const val TAG = "SkerryKeepAlive"
+    }
+}
+
+/**
+ * The "keep the CPU awake" switch, stored on the device.
+ *
+ * Its own object because two sides read it and neither may depend on the other: the settings screen
+ * through [AndroidKeepAlivePower], and [SessionKeepAliveService] when a session opens — the service
+ * can be re-created by the system with no Activity alive to have built anything.
+ */
+internal object KeepAliveWakeLockSetting {
+
+    private const val PREFS = "skerry_keepalive"
+    private const val KEY_WAKE_LOCK = "wake_lock_enabled"
+
+    /** Off by default: keeping the CPU awake is a battery cost only the user can agree to. */
+    fun isEnabled(context: Context): Boolean =
+        prefs(context).getBoolean(KEY_WAKE_LOCK, false)
+
+    fun set(context: Context, enabled: Boolean) {
+        prefs(context).edit().putBoolean(KEY_WAKE_LOCK, enabled).apply()
+    }
+
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}

--- a/androidApp/src/main/kotlin/app/skerry/android/KeepAliveAutostartPages.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/KeepAliveAutostartPages.kt
@@ -1,0 +1,48 @@
+package app.skerry.android
+
+import app.skerry.ui.keepalive.KeepAliveVendor
+
+/**
+ * The ROM autostart pages this app knows how to open, as plain package/activity names.
+ *
+ * A table rather than a method of [AndroidKeepAlivePower] because it has to agree with the
+ * `<queries>` block of the manifest and nothing at runtime says when it stops: an undeclared package
+ * reads as "not installed" on Android 11+, [AndroidKeepAlivePower] then falls back to the app's own
+ * details page, and the only trace is a debug log. A pure table is checkable by a test; a `when`
+ * inside a `Context`-constructed class is not.
+ *
+ * Explicit components rather than the vendors' documented-nowhere implicit actions: an implicit
+ * action is answerable by any installed app, and this one opens a page about our own background
+ * permissions.
+ */
+internal object KeepAliveAutostartPages {
+
+    /**
+     * Known autostart activities for [vendor], most current release first — each family has moved
+     * the activity between releases, and the caller tries them in order.
+     */
+    fun forVendor(vendor: KeepAliveVendor): List<Pair<String, String>> = when (vendor) {
+        KeepAliveVendor.Xiaomi -> listOf(
+            "com.miui.securitycenter" to "com.miui.permcenter.autostart.AutoStartManagementActivity",
+        )
+        KeepAliveVendor.Huawei -> listOf(
+            "com.huawei.systemmanager" to "com.huawei.systemmanager.startupmgr.ui.StartupNormalAppListActivity",
+            "com.huawei.systemmanager" to "com.huawei.systemmanager.optimize.process.ProtectActivity",
+            "com.hihonor.systemmanager" to "com.hihonor.systemmanager.startupmgr.ui.StartupNormalAppListActivity",
+        )
+        KeepAliveVendor.Oppo -> listOf(
+            "com.oplus.safecenter" to "com.oplus.safecenter.permission.startup.StartupAppListActivity",
+            "com.coloros.safecenter" to "com.coloros.safecenter.permission.startup.StartupAppListActivity",
+            "com.coloros.safecenter" to "com.coloros.safecenter.startupapp.StartupAppListActivity",
+        )
+        KeepAliveVendor.Vivo -> listOf(
+            "com.iqoo.secure" to "com.iqoo.secure.ui.phoneoptimize.AddWhiteListActivity",
+            "com.vivo.permissionmanager" to "com.vivo.permissionmanager.activity.BgStartUpManagerActivity",
+        )
+        KeepAliveVendor.Samsung, KeepAliveVendor.Other -> emptyList()
+    }
+
+    /** Every package the table names — what the manifest's `<queries>` block has to declare. */
+    val packages: Set<String>
+        get() = KeepAliveVendor.entries.flatMap { forVendor(it) }.map { it.first }.toSet()
+}

--- a/androidApp/src/main/kotlin/app/skerry/android/KeepAliveWakeLock.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/KeepAliveWakeLock.kt
@@ -1,0 +1,68 @@
+package app.skerry.android
+
+import android.os.PowerManager
+
+/**
+ * The lock itself, behind an interface so [WakeLockGate]'s transitions can be driven off a device.
+ */
+internal interface WakeLockHandle {
+    val isHeld: Boolean
+    fun acquire()
+    fun release()
+}
+
+/**
+ * Decides, and is the only thing that decides, whether a partial wake lock is held.
+ *
+ * Being a foreground service keeps the process, not the CPU: with the screen off the device still
+ * suspends between wakeups, the SSH keepalive misses its interval, and the server drops a session
+ * that was otherwise fine. So the lock is held exactly while sessions are open AND the user asked
+ * for it — off by default, because the cost is battery.
+ *
+ * Its own class because the rule spans five transitions in [SessionKeepAliveService] (a session
+ * added, the last one removed, a stray remove, an empty replay after a restart, and the switch
+ * flipped under live sessions) and a lock left held with no session drains the battery invisibly
+ * until the process dies.
+ */
+internal class WakeLockGate(private val newLock: () -> WakeLockHandle?) {
+
+    private var lock: WakeLockHandle? = null
+
+    fun sync(sessionCount: Int, enabled: Boolean) {
+        if (sessionCount == 0 || !enabled) release() else acquire()
+    }
+
+    fun release() {
+        val held = lock ?: return
+        lock = null
+        if (held.isHeld) held.release()
+    }
+
+    private fun acquire() {
+        if (lock?.isHeld == true) return
+        val held = lock ?: newLock() ?: return
+        lock = held
+        held.acquire()
+    }
+}
+
+/**
+ * Takes the lock without a timeout, on purpose. A timeout would expire under exactly the session it
+ * is there for — an overnight `tail -f` gets no events to renew on — and the lock has three ends
+ * that do not depend on one: the last session closing, the service being destroyed, and the process
+ * dying (the kernel drops a dead process's locks). The foreground notification is up the whole time,
+ * so the state is never invisible.
+ */
+internal class AndroidWakeLockHandle(private val lock: PowerManager.WakeLock) : WakeLockHandle {
+
+    override val isHeld: Boolean get() = lock.isHeld
+
+    @Suppress("WakelockTimeout")
+    override fun acquire() {
+        lock.acquire()
+    }
+
+    override fun release() {
+        lock.release()
+    }
+}

--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -980,6 +980,13 @@ class MainActivity : FragmentActivity() {
             sharedSessions = sharedSessions,
             securityLog = securityLog,
             localAi = localAi,
+            // Background power management (More -> Background & lock screen). The application
+            // context, not this Activity: the setting outlives any one of them, and the pages it
+            // opens are other apps' tasks. "Are there live sessions" is asked of the process-scoped
+            // keep-alive bridge, so flipping the switch mid-session reaches the running service.
+            keepAlivePower = AndroidKeepAlivePower(applicationContext) {
+                KeepAliveRuntime.bridge?.snapshotSessions()?.isNotEmpty() == true
+            },
         )
     }
 

--- a/androidApp/src/main/kotlin/app/skerry/android/SessionKeepAliveService.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/SessionKeepAliveService.kt
@@ -12,6 +12,7 @@ import android.content.IntentFilter
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
 import android.util.Log
 import androidx.core.content.ContextCompat
 import app.skerry.ui.keepalive.KeepAliveNotificationRegistry
@@ -40,6 +41,13 @@ class SessionKeepAliveService : Service() {
         const val ACTION_ADD = "app.skerry.android.action.KEEPALIVE_ADD"
         const val ACTION_REMOVE = "app.skerry.android.action.KEEPALIVE_REMOVE"
         const val ACTION_NOTIFICATION_DISMISSED = "app.skerry.android.action.KEEPALIVE_NOTIFICATION_DISMISSED"
+
+        /**
+         * The "keep the CPU awake" switch was flipped while sessions are already open. Without it
+         * the new value would only be read by the next connect, while the settings screen already
+         * showed it as taken.
+         */
+        const val ACTION_SYNC_WAKE_LOCK = "app.skerry.android.action.KEEPALIVE_SYNC_WAKE_LOCK"
         const val EXTRA_SESSION_ID = "app.skerry.android.extra.SESSION_ID"
         const val EXTRA_HOST_LABEL = "app.skerry.android.extra.HOST_LABEL"
         const val EXTRA_TAP_NONCE = "app.skerry.android.extra.TAP_NONCE"
@@ -53,6 +61,9 @@ class SessionKeepAliveService : Service() {
         val tapNonce: String = UUID.randomUUID().toString()
 
         private const val TAG = "SkerryKeepAlive"
+        // Shows up in `dumpsys power` and in battery attribution; the "app:reason" form is the
+        // convention the platform expects.
+        private const val WAKE_LOCK_TAG = "skerry:session-keepalive"
         private const val CHANNEL_ID = "session_keepalive"
         // One shade group for the summary + per-session notifications; without it each session is
         // a top-level notification and TalkBack announces every one separately.
@@ -79,6 +90,20 @@ class SessionKeepAliveService : Service() {
     private val sessionHosts = LinkedHashMap<String, String>()
     // Registered while the service lives; re-shows notifications when one is swiped away.
     private var dismissReceiver: BroadcastReceiver? = null
+    private val wakeLock = WakeLockGate {
+        val power = getSystemService(PowerManager::class.java)
+        if (power == null) {
+            // No PowerManager means no lock and no way to get one: sessions still run, they just
+            // suspend with the screen. Worth a line, since the switch reads as taken.
+            Log.w(TAG, "no PowerManager: open sessions will not hold the CPU awake")
+            null
+        } else {
+            AndroidWakeLockHandle(
+                power.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKE_LOCK_TAG)
+                    .also { it.setReferenceCounted(false) },
+            )
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -86,9 +111,19 @@ class SessionKeepAliveService : Service() {
     }
 
     override fun onDestroy() {
+        wakeLock.release()
         dismissReceiver?.let { unregisterReceiver(it) }
         dismissReceiver = null
         super.onDestroy()
+    }
+
+    /**
+     * Applies [WakeLockGate]'s rule to the current state: the session count, and the user's switch
+     * read fresh from the store rather than remembered, since the settings screen writes it.
+     * Called from every transition that can change either.
+     */
+    private fun syncWakeLock() {
+        wakeLock.sync(sessions.size, KeepAliveWakeLockSetting.isEnabled(this))
     }
 
     /**
@@ -148,6 +183,12 @@ class SessionKeepAliveService : Service() {
         }
         when (intent.action) {
             ACTION_REMOVE -> removeSession(intent)
+            ACTION_SYNC_WAKE_LOCK -> {
+                syncWakeLock()
+                // Nothing to keep alive: the switch was flipped as the last session was closing.
+                // This start never went foreground, so there is nothing to tear down but the service.
+                if (sessions.isEmpty) stopSelf()
+            }
             else -> addSession(intent) // ACTION_ADD; also the plain-start fallback path
         }
         return START_STICKY
@@ -174,6 +215,7 @@ class SessionKeepAliveService : Service() {
         notificationManager().cancelAll()
         val snapshot = SessionKeepAliveService.bridgeInstance?.snapshotSessions().orEmpty()
         if (snapshot.isEmpty()) {
+            wakeLock.release()
             startForegroundCompat(buildSummaryNotification(0))
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
@@ -234,6 +276,8 @@ class SessionKeepAliveService : Service() {
         val notifId = sessions.register(sessionId)
         notificationManager().notify(notifId, buildSessionNotification(hostLabel, sessionId, notifId))
         updateSummary()
+        // After the registration, not before it: the decision reads the session count.
+        syncWakeLock()
     }
 
     private fun removeSession(intent: Intent) {
@@ -244,12 +288,16 @@ class SessionKeepAliveService : Service() {
         }
         val notifId = sessions.remove(sessionId)
         if (notifId == null) { // idempotent; a lone stray remove must not leave an idle service
-            if (sessions.isEmpty) stopSelf()
+            if (sessions.isEmpty) {
+                wakeLock.release()
+                stopSelf()
+            }
             return
         }
         sessionHosts.remove(sessionId)
         notificationManager().cancel(notifId)
         if (sessions.isEmpty) {
+            wakeLock.release()
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
         } else {

--- a/androidApp/src/test/kotlin/app/skerry/android/KeepAliveAutostartPagesTest.kt
+++ b/androidApp/src/test/kotlin/app/skerry/android/KeepAliveAutostartPagesTest.kt
@@ -1,0 +1,64 @@
+package app.skerry.android
+
+import app.skerry.ui.keepalive.KeepAliveVendor
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The autostart table against the manifest that has to declare it.
+ *
+ * The two are kept by hand and fail apart silently: under Android 11 package visibility an
+ * undeclared package reads as "not installed", so the system-app check refuses it, the row falls
+ * back to this app's details page, and the only trace is a debug log. On a device the person taps
+ * "Open" under "Autostart" and lands somewhere else.
+ */
+class KeepAliveAutostartPagesTest {
+
+    @Test
+    fun everyPackageTheTableNamesIsDeclaredInTheManifest() {
+        val declared = declaredQueryPackages()
+        for (packageName in KeepAliveAutostartPages.packages) {
+            assertTrue(
+                packageName in declared,
+                "$packageName is opened by the autostart row but missing from the manifest <queries>",
+            )
+        }
+    }
+
+    /** The other direction: a package left in `<queries>` after the table dropped it. */
+    @Test
+    fun theManifestDeclaresNothingTheTableNoLongerOpens() {
+        assertEquals(KeepAliveAutostartPages.packages, declaredQueryPackages())
+    }
+
+    /**
+     * What the screen promises and what the table can deliver are the same set. A family marked as
+     * having an autostart page with no component behind it draws a row whose button can only open
+     * the app details page.
+     */
+    @Test
+    fun aFamilyHasComponentsExactlyWhenItAdvertisesAPage() {
+        for (vendor in KeepAliveVendor.entries) {
+            assertEquals(
+                vendor.hasAutostartPage,
+                KeepAliveAutostartPages.forVendor(vendor).isNotEmpty(),
+                "$vendor advertises hasAutostartPage=${vendor.hasAutostartPage} with a table that disagrees",
+            )
+        }
+    }
+
+    private fun declaredQueryPackages(): Set<String> {
+        val manifest = sequenceOf(File("src/main/AndroidManifest.xml"), File("androidApp/src/main/AndroidManifest.xml"))
+            .firstOrNull { it.exists() }
+        checkNotNull(manifest) { "AndroidManifest.xml not found from ${File(".").absolutePath}" }
+        val queries = QUERIES.find(manifest.readText())?.value.orEmpty()
+        return PACKAGE.findAll(queries).map { it.groupValues[1] }.toSet()
+    }
+
+    private companion object {
+        val QUERIES = Regex("<queries>.*?</queries>", RegexOption.DOT_MATCHES_ALL)
+        val PACKAGE = Regex("""<package\s+android:name="([^"]+)"""")
+    }
+}

--- a/androidApp/src/test/kotlin/app/skerry/android/WakeLockGateTest.kt
+++ b/androidApp/src/test/kotlin/app/skerry/android/WakeLockGateTest.kt
@@ -1,0 +1,114 @@
+package app.skerry.android
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The rule the whole feature rests on: the CPU is held exactly while sessions are open and the user
+ * asked for it. A lock left held with no session drains the battery invisibly until the process
+ * dies, and the transitions that can leave one behind — a stray remove, an empty replay after a
+ * restart, the switch turned off under a live session — are all reachable on a device.
+ */
+class WakeLockGateTest {
+
+    @Test
+    fun theLockIsTakenOnlyWithSessionsAndTheSwitchOn() {
+        val lock = FakeLock()
+        val gate = WakeLockGate { lock }
+
+        gate.sync(sessionCount = 0, enabled = true)
+        assertFalse(lock.isHeld, "no session, nothing to keep awake")
+
+        gate.sync(sessionCount = 1, enabled = false)
+        assertFalse(lock.isHeld, "the switch is off")
+
+        gate.sync(sessionCount = 1, enabled = true)
+        assertTrue(lock.isHeld)
+    }
+
+    /** The last session closing, and the switch turned off under a live one, both let go. */
+    @Test
+    fun theLockIsReleasedWhenEitherSideStops() {
+        val lock = FakeLock()
+        val gate = WakeLockGate { lock }
+
+        gate.sync(1, enabled = true)
+        gate.sync(0, enabled = true)
+        assertFalse(lock.isHeld, "the last session closed")
+
+        gate.sync(2, enabled = true)
+        assertTrue(lock.isHeld)
+        gate.sync(2, enabled = false)
+        assertFalse(lock.isHeld, "the switch was turned off with sessions still open")
+    }
+
+    /** Every teardown path calls it, including ones where nothing was ever taken. */
+    @Test
+    fun releasingIsIdempotent() {
+        val lock = FakeLock()
+        val gate = WakeLockGate { lock }
+
+        gate.release()
+        gate.release()
+        assertEquals(0, lock.releases, "nothing was held, nothing to release")
+
+        gate.sync(1, enabled = true)
+        gate.release()
+        gate.release()
+        assertEquals(1, lock.releases)
+        assertFalse(lock.isHeld)
+    }
+
+    /** Repeated syncs under an unchanged state must not stack acquisitions. */
+    @Test
+    fun holdingIsIdempotent() {
+        val lock = FakeLock()
+        val gate = WakeLockGate { lock }
+
+        repeat(3) { gate.sync(1, enabled = true) }
+        assertEquals(1, lock.acquisitions)
+        assertTrue(lock.isHeld)
+    }
+
+    /** Release drops the handle, so the next hold has to ask for a fresh one. */
+    @Test
+    fun theLockIsTakenAgainAfterARelease() {
+        val lock = FakeLock()
+        var handles = 0
+        val gate = WakeLockGate { handles++; lock }
+
+        gate.sync(1, enabled = true)
+        gate.sync(0, enabled = true)
+        gate.sync(1, enabled = true)
+        assertEquals(2, handles)
+        assertEquals(2, lock.acquisitions)
+        assertTrue(lock.isHeld)
+    }
+
+    /** A device with no PowerManager: the sessions still run, the gate just holds nothing. */
+    @Test
+    fun withoutALockToTakeTheGateStaysQuiet() {
+        val gate = WakeLockGate { null }
+        gate.sync(1, enabled = true)
+        gate.release()
+    }
+
+    private class FakeLock : WakeLockHandle {
+        var acquisitions = 0
+        var releases = 0
+        override var isHeld = false
+            private set
+
+        override fun acquire() {
+            acquisitions++
+            isHeld = true
+        }
+
+        override fun release() {
+            releases++
+            isHeld = false
+        }
+    }
+}

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -268,4 +268,29 @@
     <string name="settings_terminal_prod_warnings_desc">На хостах с тегом #prod спрашивать не только на опасных командах, но и на предупреждениях (kill, остановка сервиса, удаление пакета). В сессии под root правило про sudo не действует — там оно ничего не значит, — а разрушительные предупреждения подтверждаются в любом случае.</string>
     <string name="settings_kb_remote_group">УДАЛЁННЫЙ РАБОЧИЙ СТОЛ</string>
     <string name="settings_kb_release_keyboard">Отпустить клавиатуру (вернуть приложению)</string>
+
+    <!-- Background keep-alive (More -> Background & lock screen; Android only) -->
+    <string name="keepalive_title">Фон и экран блокировки</string>
+    <string name="keepalive_desc">При выключенном экране Android останавливает процессор, а прошивки производителей чистят фоновые приложения: keepalive перестаёт уходить, и сервер разрывает сессию.</string>
+    <string name="keepalive_device">Определено: %1$s</string>
+    <string name="keepalive_wakelock">Не давать процессору уснуть</string>
+    <string name="keepalive_wakelock_desc">Удерживается только при открытой сессии, снимается с закрытием последней. Расходует батарею.</string>
+    <string name="keepalive_wakelock_deferred">Сохранено. Открытая сессия не получила изменение; оно вступит в силу при следующем подключении.</string>
+    <string name="keepalive_battery">Оптимизация батареи</string>
+    <string name="keepalive_battery_on">Skerry исключён из Doze и App Standby.</string>
+    <string name="keepalive_battery_off">Система может останавливать Skerry в фоне. В открывшемся списке переключитесь на все приложения и выберите для Skerry «Не оптимизировать».</string>
+    <string name="keepalive_autostart">Автозапуск и работа в фоне</string>
+    <string name="keepalive_autostart_desc">У прошивки свой белый список. Без записи в нём службу выгружают независимо от настройки Android.</string>
+    <string name="keepalive_recents">Закрепление в недавних и очистка при блокировке</string>
+    <string name="keepalive_recents_xiaomi">Безопасность → Батарея → «Очищать память при блокировке»: Никогда. В недавних задержите карточку Skerry и нажмите замок.</string>
+    <string name="keepalive_recents_samsung">Батарея → Ограничения фоновой работы: не держите Skerry в «Спящих приложениях», задайте «Без ограничений».</string>
+    <string name="keepalive_recents_generic">Закрепите карточку Skerry в недавних и отключите очистку памяти при блокировке в системных настройках батареи.</string>
+    <string name="keepalive_open">Открыть</string>
+    <string name="keepalive_exempt">Исключён</string>
+    <string name="keepalive_not_exempt">Не исключён</string>
+    <string name="keepalive_vendor_xiaomi">Xiaomi / Redmi / POCO</string>
+    <string name="keepalive_vendor_huawei">Huawei / Honor</string>
+    <string name="keepalive_vendor_oppo">OPPO / OnePlus / realme</string>
+    <string name="keepalive_vendor_vivo">vivo / iQOO</string>
+    <string name="keepalive_vendor_samsung">Samsung</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -268,4 +268,29 @@
     <string name="settings_terminal_prod_warnings_desc">在带 #prod 标签的主机上，除危险命令外也确认警告级命令（kill、停止服务、卸载软件包）。root 会话不适用 sudo 规则（在那里没有意义），但无论如何都会确认破坏性警告。</string>
     <string name="settings_kb_remote_group">远程桌面</string>
     <string name="settings_kb_release_keyboard">释放键盘（交还给应用）</string>
+
+    <!-- Background keep-alive (More -> Background & lock screen; Android only) -->
+    <string name="keepalive_title">后台与锁屏</string>
+    <string name="keepalive_desc">锁屏后 Android 会挂起 CPU，厂商固件也会清理后台应用：keepalive 停止发出，服务器随即断开会话。</string>
+    <string name="keepalive_device">已识别：%1$s</string>
+    <string name="keepalive_wakelock">保持 CPU 唤醒</string>
+    <string name="keepalive_wakelock_desc">仅在有会话打开时持有，最后一个会话关闭即释放。会增加耗电。</string>
+    <string name="keepalive_wakelock_deferred">已保存。未能通知已打开的会话；将在下次连接时生效。</string>
+    <string name="keepalive_battery">电池优化</string>
+    <string name="keepalive_battery_on">Skerry 已排除在 Doze 与 App Standby 之外。</string>
+    <string name="keepalive_battery_off">系统可能在后台挂起 Skerry。在打开的列表中切换到全部应用，并将 Skerry 设为“不优化”。</string>
+    <string name="keepalive_autostart">自启动与后台运行</string>
+    <string name="keepalive_autostart_desc">固件有自己的白名单。不在其中时，无论 Android 设置如何，服务都会被清理。</string>
+    <string name="keepalive_recents">多任务锁定与锁屏清理</string>
+    <string name="keepalive_recents_xiaomi">安全中心 → 电池 →“锁屏后清理内存”设为“永不”。在多任务界面长按 Skerry 卡片并点击锁图标。</string>
+    <string name="keepalive_recents_samsung">电池 → 后台使用限制：不要让 Skerry 进入“深度休眠应用”，并设为“无限制”。</string>
+    <string name="keepalive_recents_generic">在多任务界面锁定 Skerry 卡片，并在系统电池设置中关闭锁屏清理内存。</string>
+    <string name="keepalive_open">打开</string>
+    <string name="keepalive_exempt">已排除</string>
+    <string name="keepalive_not_exempt">未排除</string>
+    <string name="keepalive_vendor_xiaomi">Xiaomi / Redmi / POCO</string>
+    <string name="keepalive_vendor_huawei">Huawei / Honor</string>
+    <string name="keepalive_vendor_oppo">OPPO / OnePlus / realme</string>
+    <string name="keepalive_vendor_vivo">vivo / iQOO</string>
+    <string name="keepalive_vendor_samsung">Samsung</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -268,4 +268,29 @@
     <string name="settings_terminal_prod_warnings_desc">On hosts tagged #prod also confirm warnings (kill, stopping a service, uninstalling a package), not only dangerous commands. A root session drops the sudo rule — it says nothing there — and confirms destructive warnings either way.</string>
     <string name="settings_kb_remote_group">REMOTE DESKTOP</string>
     <string name="settings_kb_release_keyboard">Release the keyboard (back to the app)</string>
+
+    <!-- Background keep-alive (More -> Background & lock screen; Android only) -->
+    <string name="keepalive_title">Background &amp; lock screen</string>
+    <string name="keepalive_desc">With the screen off Android suspends the CPU and OEM firmware clears background apps: the keepalive stops going out and the server drops the session.</string>
+    <string name="keepalive_device">Detected: %1$s</string>
+    <string name="keepalive_wakelock">Keep the CPU awake</string>
+    <string name="keepalive_wakelock_desc">Held only while a session is open, released when the last one closes. Costs battery.</string>
+    <string name="keepalive_wakelock_deferred">Saved. The open session was not told; it takes effect on the next connection.</string>
+    <string name="keepalive_battery">Battery optimization</string>
+    <string name="keepalive_battery_on">Skerry is exempt from Doze and App Standby.</string>
+    <string name="keepalive_battery_off">The system may suspend Skerry in the background. In the list that opens switch to all apps and set Skerry to “Don't optimize”.</string>
+    <string name="keepalive_autostart">Autostart and background</string>
+    <string name="keepalive_autostart_desc">The firmware keeps a whitelist of its own. Without an entry there the service is killed regardless of the Android setting.</string>
+    <string name="keepalive_recents">Recents lock and lock-screen cleanup</string>
+    <string name="keepalive_recents_xiaomi">Security → Battery → “Clear memory on lock screen”: Never. In Recents hold the Skerry card and tap the lock.</string>
+    <string name="keepalive_recents_samsung">Battery → Background usage limits: keep Skerry out of “Deep sleeping apps” and set it to Unrestricted.</string>
+    <string name="keepalive_recents_generic">Lock the Skerry card in Recents and turn off lock-screen memory cleanup in the system battery settings.</string>
+    <string name="keepalive_open">Open</string>
+    <string name="keepalive_exempt">Exempt</string>
+    <string name="keepalive_not_exempt">Not exempt</string>
+    <string name="keepalive_vendor_xiaomi">Xiaomi / Redmi / POCO</string>
+    <string name="keepalive_vendor_huawei">Huawei / Honor</string>
+    <string name="keepalive_vendor_oppo">OPPO / OnePlus / realme</string>
+    <string name="keepalive_vendor_vivo">vivo / iQOO</string>
+    <string name="keepalive_vendor_samsung">Samsung</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/AppDependencies.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/AppDependencies.kt
@@ -85,4 +85,9 @@ data class AppDependencies(
     val securityLog: SecurityLog? = null,
     /** Local AI: model store + downloader + runtime; `null` for preview/mock without the subsystem. */
     val localAi: LocalAiDeps? = null,
+    /**
+     * The phone's background power management (wake lock, battery exemption, the ROM's autostart
+     * page); `null` on every platform that has none, and the More screen then drops the row.
+     */
+    val keepAlivePower: app.skerry.ui.keepalive.KeepAlivePower? = null,
 )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
@@ -14,6 +14,7 @@ import app.skerry.shared.vault.SecurityLog
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultBiometrics
 import app.skerry.ui.ai.AiAssistantController
+import app.skerry.ui.keepalive.KeepAlivePower
 import app.skerry.ui.terminal.CastOpenResult
 import app.skerry.ui.terminal.openCastFile
 import app.skerry.ui.host.HostManagerController
@@ -344,3 +345,10 @@ val LocalUpdates: ProvidableCompositionLocal<UpdateNoticeController?> = staticCo
  */
 val LocalCastPicker: ProvidableCompositionLocal<suspend () -> CastOpenResult> =
     staticCompositionLocalOf { ::openCastFile }
+
+/**
+ * The phone's background power management (wake lock, battery exemption, the ROM's autostart page)
+ * — More → "Background & lock screen". `null` on desktop and in preview, where the More row is
+ * dropped: there is no Doze and no OEM task killer to configure.
+ */
+val LocalKeepAlivePower: ProvidableCompositionLocal<KeepAlivePower?> = staticCompositionLocalOf { null }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -52,7 +52,7 @@ enum class MobileTab(val icon: String) {
  * from Hosts, the framebuffer from Desktops or Sessions, SFTP (Files) via the host card's SFTP
  * button, and Vault/Snippets/Ports/Known/Team from the More tab.
  */
-enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Vault, Snippets, Runbooks, Ports, Known, Team, Appearance, Sync, Ai, Security, Trash, About }
+enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Vault, Snippets, Runbooks, Ports, Known, Team, Appearance, Sync, Ai, Security, KeepAlive, Trash, About }
 
 /**
  * Push screens that keep the bottom navigation up. The terminal is one: per the template it is a

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/BatteryExemptionState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/BatteryExemptionState.kt
@@ -1,0 +1,40 @@
+package app.skerry.ui.keepalive
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+/**
+ * Whether the system currently exempts the app from battery optimisation, re-read every time the
+ * window comes back.
+ *
+ * The answer is changed in a *system* page we sent the user to, so a value read once at composition
+ * is stale exactly when it matters: the person taps "Open", allows the exemption, comes back, and
+ * the screen still says the system may suspend the app. `ON_RESUME` rather than `ON_START` because
+ * the settings list is a full activity of another app, and returning from it is a resume.
+ *
+ * `null` power (desktop, preview) reads as not exempt, and returns before touching
+ * [LocalLifecycleOwner]: that local has no default value and throws where nothing provides one, which
+ * is every offscreen mobile render (`renderMobile` in `Screenshot.kt` wraps no lifecycle owner around
+ * the scene). A screen that only draws must not need one.
+ */
+@Composable
+internal fun rememberBatteryExemption(power: KeepAlivePower?): Boolean {
+    if (power == null) return false
+    val owner = LocalLifecycleOwner.current
+    var reads by remember(power) { mutableStateOf(0) }
+    DisposableEffect(owner, power) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) reads++
+        }
+        owner.lifecycle.addObserver(observer)
+        onDispose { owner.lifecycle.removeObserver(observer) }
+    }
+    return remember(power, reads) { power.isExemptFromBatteryOptimization() }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/KeepAlivePower.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/KeepAlivePower.kt
@@ -1,0 +1,96 @@
+package app.skerry.ui.keepalive
+
+/**
+ * The phone's own power management, and what a person can be sent to change about it.
+ *
+ * Android only. The foreground service behind [SessionKeepAliveBridge] keeps the *process* alive,
+ * which is not the same as keeping the *connection* alive: with the screen off the CPU still
+ * suspends, so the keepalive timers slip past the server's idle limit, and an OEM ROM still kills
+ * a whitelisted-nowhere app on its own schedule. Every remedy for that sits outside the app — a
+ * partial wake lock, a battery-optimisation exemption, the ROM's autostart list — so this is the
+ * one surface that owns them. Desktop supplies nothing and the More screen drops the row.
+ *
+ * Deliberately not folded into [SessionKeepAliveBridge]: that is the session hot path (must never
+ * throw, called from coroutine workers, one instance per process), this is driven by taps and
+ * opens other apps' activities.
+ */
+interface KeepAlivePower {
+
+    /** The ROM family: it decides what the steps say and which system page a step opens. */
+    val vendor: KeepAliveVendor
+
+    /** Raw `Build.MANUFACTURER`, shown when [vendor] is [KeepAliveVendor.Other], which has no name of its own. */
+    val manufacturer: String
+
+    /**
+     * Whether the CPU is held awake while at least one session is open. Off by default: it is a
+     * battery trade-off only the user can make. Stored on the device, not in the account — it
+     * describes this phone.
+     */
+    val wakeLockEnabled: Boolean
+
+    /**
+     * Stores [enabled] and pushes it to the sessions already running.
+     *
+     * Returns false when the value was stored but could not reach them — the system refuses a
+     * background service start often enough that the caller has to be able to say so, rather than
+     * leave a switch reading "on" over sessions still running without the lock. The next connect
+     * re-reads the store either way, so the failure is bounded, not permanent.
+     */
+    fun setWakeLockEnabled(enabled: Boolean): Boolean
+
+    /**
+     * Whether the system exempts this app from Doze and App Standby. Read again whenever the screen
+     * resumes rather than cached: the answer changes in a system page we navigated away to.
+     */
+    fun isExemptFromBatteryOptimization(): Boolean
+
+    /** Opens the system's list of battery-optimised apps. */
+    fun openBatteryOptimizationSettings()
+
+    /** Opens the ROM's autostart page. Only offered when [KeepAliveVendor.hasAutostartPage]. */
+    fun openAutostartSettings()
+
+    /** Opens this app's system details page — the one page that exists on every device. */
+    fun openAppDetailsSettings()
+}
+
+/**
+ * ROM families that manage background apps their own way, grouped by the settings app they share:
+ * Redmi and POCO are Xiaomi's MIUI/HyperOS, Honor still ships Huawei's manager under its own
+ * package, OnePlus and realme are ColorOS, iQOO is vivo's OriginOS.
+ *
+ * [hasAutostartPage] is whether that family has an autostart whitelist to send someone to at all.
+ * Samsung is named without one on purpose: its background killing is real ("Deep sleeping apps"),
+ * but it lives inside Device care with no page we may open directly, so the step is words only.
+ */
+enum class KeepAliveVendor(val hasAutostartPage: Boolean) {
+    Xiaomi(true),
+    Huawei(true),
+    Oppo(true),
+    Vivo(true),
+    Samsung(false),
+    Other(false),
+}
+
+/**
+ * [manufacturer] (`Build.MANUFACTURER`) to the ROM family it belongs to.
+ *
+ * Matched inside the string rather than against it: firmware writes the legal entity as often as
+ * the brand ("Xiaomi Communications Co., Ltd."). The brand tokens are long and specific enough that
+ * a substring match cannot pick the wrong family.
+ */
+fun keepAliveVendorOf(manufacturer: String): KeepAliveVendor {
+    val name = manufacturer.lowercase()
+    return KeepAliveVendor.entries.firstOrNull { vendor -> brandsOf(vendor).any { it in name } }
+        ?: KeepAliveVendor.Other
+}
+
+private fun brandsOf(vendor: KeepAliveVendor): List<String> = when (vendor) {
+    KeepAliveVendor.Xiaomi -> listOf("xiaomi", "redmi", "poco")
+    KeepAliveVendor.Huawei -> listOf("huawei", "honor")
+    KeepAliveVendor.Oppo -> listOf("oppo", "oplus", "oneplus", "realme")
+    KeepAliveVendor.Vivo -> listOf("vivo", "iqoo")
+    KeepAliveVendor.Samsung -> listOf("samsung")
+    KeepAliveVendor.Other -> emptyList()
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/KeepAliveVendorLabel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/KeepAliveVendorLabel.kt
@@ -1,0 +1,30 @@
+package app.skerry.ui.keepalive
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.keepalive_vendor_huawei
+import app.skerry.ui.generated.resources.keepalive_vendor_oppo
+import app.skerry.ui.generated.resources.keepalive_vendor_samsung
+import app.skerry.ui.generated.resources.keepalive_vendor_vivo
+import app.skerry.ui.generated.resources.keepalive_vendor_xiaomi
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * What the screen calls the detected ROM family. A recognised family names every brand it covers,
+ * so a POCO owner can tell the Xiaomi steps are meant for them; an unrecognised one falls back to
+ * what the firmware calls itself.
+ *
+ * That fallback goes through [untrustedLabel]: `Build.MANUFACTURER` is a string a custom ROM sets,
+ * and this one is drawn next to instructions — a bidi override in it would rewrite the line it
+ * sits on.
+ */
+@Composable
+internal fun KeepAliveVendor.label(manufacturer: String): String = when (this) {
+    KeepAliveVendor.Xiaomi -> stringResource(Res.string.keepalive_vendor_xiaomi)
+    KeepAliveVendor.Huawei -> stringResource(Res.string.keepalive_vendor_huawei)
+    KeepAliveVendor.Oppo -> stringResource(Res.string.keepalive_vendor_oppo)
+    KeepAliveVendor.Vivo -> stringResource(Res.string.keepalive_vendor_vivo)
+    KeepAliveVendor.Samsung -> stringResource(Res.string.keepalive_vendor_samsung)
+    KeepAliveVendor.Other -> untrustedLabel(manufacturer)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -284,6 +284,9 @@ fun MobileDesignApp(
         LocalSync provides deps.sync,
         // Teams — More → "Team" push screen (sharing hosts/snippets between accounts).
         LocalTeams provides deps.teams,
+        // Background power management (wake lock, battery exemption, autostart) — More -> "Background
+        // & lock screen"; null off Android, and the row disappears with it.
+        app.skerry.ui.app.LocalKeepAlivePower provides deps.keepAlivePower,
         app.skerry.ui.app.LocalSessionShare provides deps.sessionShare,
         app.skerry.ui.app.LocalSharedSessions provides deps.sharedSessions,
     ) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileKeepAliveView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileKeepAliveView.kt
@@ -1,0 +1,168 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.app.LocalKeepAlivePower
+import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.Notice
+import app.skerry.ui.design.StatusAnnouncer
+import app.skerry.ui.design.ToggleRow
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.keepalive_autostart
+import app.skerry.ui.generated.resources.keepalive_autostart_desc
+import app.skerry.ui.generated.resources.keepalive_battery
+import app.skerry.ui.generated.resources.keepalive_battery_off
+import app.skerry.ui.generated.resources.keepalive_battery_on
+import app.skerry.ui.generated.resources.keepalive_desc
+import app.skerry.ui.generated.resources.keepalive_device
+import app.skerry.ui.generated.resources.keepalive_open
+import app.skerry.ui.generated.resources.keepalive_recents
+import app.skerry.ui.generated.resources.keepalive_recents_generic
+import app.skerry.ui.generated.resources.keepalive_recents_samsung
+import app.skerry.ui.generated.resources.keepalive_recents_xiaomi
+import app.skerry.ui.generated.resources.keepalive_title
+import app.skerry.ui.generated.resources.keepalive_wakelock
+import app.skerry.ui.generated.resources.keepalive_wakelock_deferred
+import app.skerry.ui.generated.resources.keepalive_wakelock_desc
+import app.skerry.ui.keepalive.KeepAliveVendor
+import app.skerry.ui.keepalive.label
+import app.skerry.ui.keepalive.rememberBatteryExemption
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * More → "Background & lock screen" push screen (Android only — the More row is absent where no
+ * [app.skerry.ui.keepalive.KeepAlivePower] is supplied).
+ *
+ * The one setting the app owns is the wake lock; the rest is the firmware's, so each row states what
+ * the system does and what to change about it. A row offers "Open" only where it has a page of its
+ * own to open: the autostart row is drawn for the ROM families that have one, and the recents row —
+ * whose steps live in the ROM's own security app and in the task switcher — offers nothing, because
+ * a button landing on this app's details page under those words would be a lie.
+ *
+ * Without a power hook (preview/offscreen) every row is inert: the screen still draws so the
+ * layout can be rendered, but nothing pretends to be configurable.
+ */
+@Composable
+fun MobileKeepAliveScreen(state: MobileDesignState) {
+    val power = LocalKeepAlivePower.current
+    val vendor = power?.vendor ?: KeepAliveVendor.Other
+    val exempt = rememberBatteryExemption(power)
+    // Mirrors the stored flag so the switch answers the tap; the store is the source of truth on
+    // the next entry (and for the service, which reads it when a session opens).
+    var wakeLock by remember(power) { mutableStateOf(power?.wakeLockEnabled == true) }
+    // The store took the value but the running session did not; the next connect will.
+    var deferred by remember(power) { mutableStateOf(false) }
+    val batteryStatus = stringResource(if (exempt) Res.string.keepalive_battery_on else Res.string.keepalive_battery_off)
+    val deferredNote = stringResource(Res.string.keepalive_wakelock_deferred)
+
+    Box(Modifier.fillMaxSize().background(Skerry.colors.bg)) {
+        Column(Modifier.fillMaxSize()) {
+            MobilePushHeader(stringResource(Res.string.keepalive_title), onBack = state::pop)
+            Column(Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(horizontal = 18.dp)) {
+                Txt(
+                    stringResource(Res.string.keepalive_desc),
+                    color = Skerry.colors.dim,
+                    size = 12.5.sp,
+                    lineHeight = 18.sp,
+                    modifier = Modifier.padding(top = 2.dp, bottom = 8.dp),
+                )
+
+                ToggleRow(
+                    label = stringResource(Res.string.keepalive_wakelock),
+                    subtitle = stringResource(Res.string.keepalive_wakelock_desc),
+                    subtitleColor = Skerry.colors.dim,
+                    labelSize = 14.5.sp,
+                    on = wakeLock,
+                    onToggle = {
+                        val target = power ?: return@ToggleRow
+                        wakeLock = !wakeLock
+                        deferred = !target.setWakeLockEnabled(wakeLock)
+                    },
+                    modifier = Modifier.padding(vertical = 14.dp),
+                )
+                // Composed across both states, not inserted with the message: a live region only
+                // reports a change on a node that outlives it (see StatusAnnouncer).
+                StatusAnnouncer(if (deferred) deferredNote else "")
+                if (deferred) {
+                    Notice(
+                        deferredNote,
+                        // Drawn for the eye only: the announcer above already carries this sentence,
+                        // and left readable the line would be heard twice in a row.
+                        Modifier.padding(bottom = 12.dp).semantics { hideFromAccessibility() },
+                    )
+                }
+                HLine()
+
+                MobileSettingLinkRow(
+                    label = stringResource(Res.string.keepalive_battery),
+                    subtitle = batteryStatus,
+                    action = stringResource(Res.string.keepalive_open),
+                    onAction = power?.let { { it.openBatteryOptimizationSettings() } },
+                )
+                // The exemption is granted in a system page, so the status changes while the screen
+                // is stopped and comes back silently — visible to a sighted user, to no one else.
+                StatusAnnouncer(batteryStatus)
+                HLine()
+
+                if (vendor.hasAutostartPage) {
+                    MobileSettingLinkRow(
+                        label = stringResource(Res.string.keepalive_autostart),
+                        subtitle = stringResource(Res.string.keepalive_autostart_desc),
+                        action = stringResource(Res.string.keepalive_open),
+                        onAction = power?.let { { it.openAutostartSettings() } },
+                    )
+                    HLine()
+                }
+
+                MobileSettingNoteRow(
+                    label = stringResource(Res.string.keepalive_recents),
+                    subtitle = stringResource(recentsAdviceFor(vendor)),
+                )
+                HLine()
+
+                // Only with a device to name: without a power hook this would read "Detected: ".
+                if (power != null) {
+                    Txt(
+                        stringResource(Res.string.keepalive_device, vendor.label(power.manufacturer)),
+                        color = Skerry.colors.faint,
+                        size = 11.5.sp,
+                        modifier = Modifier.padding(vertical = 12.dp),
+                    )
+                }
+                Spacer(Modifier.height(24.dp))
+            }
+        }
+    }
+}
+
+/**
+ * Where a ROM family hides its lock-screen cleanup. Named per family only where the path is one we
+ * can actually spell — everyone else gets the shape of the setting rather than a menu path that
+ * doesn't exist on their phone.
+ */
+private fun recentsAdviceFor(vendor: KeepAliveVendor) = when (vendor) {
+    KeepAliveVendor.Xiaomi -> Res.string.keepalive_recents_xiaomi
+    KeepAliveVendor.Samsung -> Res.string.keepalive_recents_samsung
+    else -> Res.string.keepalive_recents_generic
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -21,6 +21,9 @@ import androidx.compose.ui.unit.dp
 import app.skerry.shared.ai.AiProviderKind
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.appearance_title
+import app.skerry.ui.generated.resources.keepalive_exempt
+import app.skerry.ui.generated.resources.keepalive_not_exempt
+import app.skerry.ui.generated.resources.keepalive_title
 import app.skerry.ui.generated.resources.lib_snippets_screen_title
 import app.skerry.ui.generated.resources.runbook_section
 import app.skerry.ui.generated.resources.more_about
@@ -45,6 +48,8 @@ import app.skerry.ui.generated.resources.settings_update_status
 import app.skerry.ui.generated.resources.vault_item_count
 import app.skerry.ui.generated.resources.vault_title
 import app.skerry.ui.app.LocalCredentials
+import app.skerry.ui.app.LocalKeepAlivePower
+import app.skerry.ui.keepalive.rememberBatteryExemption
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
@@ -125,6 +130,20 @@ fun MobileMoreScreen(state: MobileDesignState, onLock: (() -> Unit)?) {
             // "Security" section: master password, biometrics, auto-lock, event log. Live path is
             // behind the gate (vault present); in preview the row is inert (nothing to configure without a vault).
             MoreRow("shield_lock", Skerry.colors.cyanBright, stringResource(Res.string.settings_security_title), null, Skerry.colors.dim, onClick = if (preview) null else { -> state.push(MobileRoute.Security) })
+            // Background & lock screen: the wake lock and the system pages that decide whether a
+            // session survives the screen going off. Android only — nothing supplies the hook
+            // elsewhere, and a row that opens a screen full of settings this OS does not have would
+            // be worse than no row. The subtitle is the one state the system will tell us.
+            val power = LocalKeepAlivePower.current
+            val exempt = rememberBatteryExemption(power)
+            if (power != null) {
+                MoreRow(
+                    "battery_saver", Skerry.colors.cyanBright, stringResource(Res.string.keepalive_title),
+                    stringResource(if (exempt) Res.string.keepalive_exempt else Res.string.keepalive_not_exempt),
+                    if (exempt) Skerry.colors.dim else Skerry.colors.amber,
+                    onClick = { state.push(MobileRoute.KeepAlive) },
+                )
+            }
             // Trash: records deleted on any device of the account, restorable within the retention
             // window. Live path only — without a vault there is nothing to list.
             MoreRow("delete", Skerry.colors.cyanBright, stringResource(Res.string.more_trash), null, Skerry.colors.dim, onClick = if (preview) null else { -> state.push(MobileRoute.Trash) })

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSecurityScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSecurityScreen.kt
@@ -2,7 +2,6 @@ package app.skerry.ui.mobile
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -124,52 +123,30 @@ fun MobileSecurityScreen(state: MobileDesignState) {
                 val lastChange by produceState<String?>(null, controller, reload) {
                     value = withContext(Dispatchers.Default) { controller?.lastPasswordChangeAt() }
                 }
-                Row(Modifier.fillMaxWidth().padding(vertical = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Column(Modifier.weight(1f)) {
-                        Txt(
-                            stringResource(if (syncConfigured) Res.string.settings_security_account_password else Res.string.settings_security_master_password),
-                            color = Skerry.colors.text,
-                            size = 14.5.sp,
-                        )
-                        Txt(
-                            if (syncConfigured) stringResource(Res.string.settings_security_account_password_desc) else masterPasswordSubtitle(lastChange),
-                            color = Skerry.colors.dim,
-                            size = 11.5.sp,
-                            modifier = Modifier.padding(top = 3.dp),
-                        )
-                    }
-                    // Changing the password requires a live vault; without one it's dimmed/inert.
-                    Txt(
-                        stringResource(Res.string.settings_change),
-                        color = if (controller != null) Skerry.colors.cyanBright else Skerry.colors.faint,
-                        size = 13.sp,
-                        weight = FontWeight.Medium,
-                        modifier = if (controller != null) {
-                            Modifier.clickable { if (syncConfigured) changeAccountPwOpen = true else changePwOpen = true }
-                        } else {
-                            Modifier
-                        },
-                    )
-                }
+                // Changing the password requires a live vault; without one the row is dimmed/inert.
+                MobileSettingLinkRow(
+                    label = stringResource(if (syncConfigured) Res.string.settings_security_account_password else Res.string.settings_security_master_password),
+                    subtitle = if (syncConfigured) stringResource(Res.string.settings_security_account_password_desc) else masterPasswordSubtitle(lastChange),
+                    action = stringResource(Res.string.settings_change),
+                    onAction = if (controller != null) {
+                        { if (syncConfigured) changeAccountPwOpen = true else changePwOpen = true }
+                    } else {
+                        null
+                    },
+                )
                 HLine()
 
                 // Biometric unlock: row shows only when the factor is available (nothing to configure
                 // otherwise). A device whose enclave refuses to decrypt the vault (#23) gets the reason
                 // and a re-check instead of a toggle that can't work.
                 if (controller != null && controller.biometricUnsupported) {
-                    Row(Modifier.fillMaxWidth().padding(vertical = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        Column(Modifier.weight(1f)) {
-                            Txt(stringResource(Res.string.settings_security_biometric), color = Skerry.colors.faint, size = 14.5.sp)
-                            Txt(stringResource(Res.string.settings_security_biometric_unsupported), color = Skerry.colors.dim, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
-                        }
-                        Txt(
-                            stringResource(Res.string.settings_security_biometric_recheck),
-                            color = Skerry.colors.cyanBright,
-                            size = 13.sp,
-                            weight = FontWeight.Medium,
-                            modifier = Modifier.clickable { controller.recheckBiometricSupport(); reload++ },
-                        )
-                    }
+                    MobileSettingLinkRow(
+                        label = stringResource(Res.string.settings_security_biometric),
+                        subtitle = stringResource(Res.string.settings_security_biometric_unsupported),
+                        action = stringResource(Res.string.settings_security_biometric_recheck),
+                        onAction = { controller.recheckBiometricSupport(); reload++ },
+                        labelColor = Skerry.colors.faint,
+                    )
                     HLine()
                 } else if (controller != null && controller.canEnableBiometric()) {
                     // Prompt strings resolved in composable scope (stringResource can't be called in the onToggle lambda).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionActions.kt
@@ -135,6 +135,7 @@ internal fun MobileRoutePane(state: MobileDesignState, route: MobileRoute) {
             MobileRoute.Sync -> MobileSyncScreen(state)
             MobileRoute.Ai -> MobileAiScreen(state)
             MobileRoute.Security -> MobileSecurityScreen(state)
+            MobileRoute.KeepAlive -> MobileKeepAliveScreen(state)
             MobileRoute.Trash -> MobileTrashScreen(state)
             MobileRoute.About -> MobileAboutScreen(state)
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSettingsControls.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSettingsControls.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -71,6 +73,77 @@ internal fun MoreRow(
         if (onClick != null && labelColor != Skerry.colors.sunset) Sym("chevron_right", size = 20.sp, color = Skerry.colors.faint)
     }
     if (divider) HLine(modifier = Modifier.padding(horizontal = 12.dp))
+}
+
+/**
+ * A setting that is not a switch but a place to go: name and explanation on the leading edge, one
+ * action word on the trailing one. [onAction] == null dims the word and takes the click away — the
+ * shape a settings row wears when the thing behind it isn't available yet.
+ *
+ * Shared because the Security screen ("Change", "Re-check") and the keep-alive screen ("Open") all
+ * draw the same row, and the third copy is where a shape stops being a coincidence.
+ *
+ * The click sits on the whole row, not on the word: a bare word is a 30x17dp target under the 24dp
+ * floor of WCAG 2.5.8, and a clickable leaf merges the row's semantics into itself, so a screen
+ * reader stepping through controls hears three identical "Open, button" stops with the labels they
+ * belong to left behind in the text it skipped.
+ */
+@Composable
+internal fun MobileSettingLinkRow(
+    label: String,
+    subtitle: String,
+    action: String,
+    onAction: (() -> Unit)?,
+    labelColor: Color = Skerry.colors.text,
+) {
+    val clickable = if (onAction != null) {
+        Modifier.clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = null,
+            role = Role.Button,
+            onClick = onAction,
+        )
+    } else {
+        Modifier
+    }
+    SettingRowShape(label, subtitle, labelColor, clickable) {
+        Txt(
+            action,
+            color = if (onAction != null) Skerry.colors.cyanBright else Skerry.colors.faint,
+            size = 13.sp,
+            weight = FontWeight.Medium,
+        )
+    }
+}
+
+/**
+ * The same row with nothing to open: a setting that lives entirely in the firmware, where all this
+ * screen can do is name it and spell out the steps.
+ */
+@Composable
+internal fun MobileSettingNoteRow(label: String, subtitle: String) {
+    SettingRowShape(label, subtitle, Skerry.colors.text, Modifier) {}
+}
+
+@Composable
+private fun SettingRowShape(
+    label: String,
+    subtitle: String,
+    labelColor: Color,
+    clickable: Modifier,
+    trailing: @Composable () -> Unit,
+) {
+    Row(
+        Modifier.fillMaxWidth().then(clickable).padding(vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Column(Modifier.weight(1f)) {
+            Txt(label, color = labelColor, size = 14.5.sp)
+            Txt(subtitle, color = Skerry.colors.dim, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
+        }
+        trailing()
+    }
 }
 
 // Security (More -> Security push screen).

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/keepalive/KeepAliveVendorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/keepalive/KeepAliveVendorTest.kt
@@ -1,0 +1,66 @@
+package app.skerry.ui.keepalive
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * The one piece of the keep-alive power screen that is pure logic: which ROM family a
+ * `Build.MANUFACTURER` string belongs to. It decides both what the steps say and which system page
+ * a step opens, and every device reports it differently — a Redmi says "Xiaomi", a POCO sometimes
+ * says "POCO", a HONOR says "HONOR" in caps.
+ */
+class KeepAliveVendorTest {
+
+    @Test
+    fun xiaomiFamilyCoversRedmiAndPoco() {
+        assertEquals(KeepAliveVendor.Xiaomi, keepAliveVendorOf("Xiaomi"))
+        assertEquals(KeepAliveVendor.Xiaomi, keepAliveVendorOf("Redmi"))
+        assertEquals(KeepAliveVendor.Xiaomi, keepAliveVendorOf("POCO"))
+    }
+
+    @Test
+    fun huaweiFamilyCoversHonor() {
+        assertEquals(KeepAliveVendor.Huawei, keepAliveVendorOf("HUAWEI"))
+        assertEquals(KeepAliveVendor.Huawei, keepAliveVendorOf("HONOR"))
+    }
+
+    @Test
+    fun oppoFamilyCoversOnePlusAndRealme() {
+        assertEquals(KeepAliveVendor.Oppo, keepAliveVendorOf("OPPO"))
+        assertEquals(KeepAliveVendor.Oppo, keepAliveVendorOf("OnePlus"))
+        assertEquals(KeepAliveVendor.Oppo, keepAliveVendorOf("realme"))
+    }
+
+    @Test
+    fun vivoFamilyCoversIqoo() {
+        assertEquals(KeepAliveVendor.Vivo, keepAliveVendorOf("vivo"))
+        assertEquals(KeepAliveVendor.Vivo, keepAliveVendorOf("iQOO"))
+    }
+
+    @Test
+    fun samsungIsNamedButHasNoAutostartPage() {
+        assertEquals(KeepAliveVendor.Samsung, keepAliveVendorOf("samsung"))
+        assertFalse(KeepAliveVendor.Samsung.hasAutostartPage)
+    }
+
+    /** A name the list doesn't know, and an empty one (an emulator reports neither) — no page to open. */
+    @Test
+    fun unknownAndBlankFallBackToOther() {
+        assertEquals(KeepAliveVendor.Other, keepAliveVendorOf("Google"))
+        assertEquals(KeepAliveVendor.Other, keepAliveVendorOf(""))
+        assertEquals(KeepAliveVendor.Other, keepAliveVendorOf("   "))
+        assertFalse(KeepAliveVendor.Other.hasAutostartPage)
+    }
+
+    /**
+     * The name is matched inside the string, not against it: firmware writes "Xiaomi Communications"
+     * and "vivo Mobile Communication" as often as the bare brand.
+     */
+    @Test
+    fun matchesTheBrandInsideALongerName() {
+        assertEquals(KeepAliveVendor.Xiaomi, keepAliveVendorOf("Xiaomi Communications Co., Ltd."))
+        assertEquals(KeepAliveVendor.Vivo, keepAliveVendorOf("vivo Mobile Communication Co., Ltd."))
+    }
+
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.test.runDesktopComposeUiTest
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import app.skerry.ui.AppDependencies
+import app.skerry.ui.keepalive.KeepAlivePower
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shell_tip_files
 import app.skerry.ui.generated.resources.shell_tip_record
@@ -324,6 +325,8 @@ internal fun runMobileShell(
     size: DpSize = DpSize(PHONE_WIDTH, PHONE_HEIGHT),
     /** System font scale, for the layouts that have to survive one: 1f is the phone's default. */
     fontScale: Float = 1f,
+    /** Android supplies one; the rows that only exist with it are tested through a fake. */
+    keepAlivePower: KeepAlivePower? = null,
     body: ComposeUiTest.(MobileShell) -> Unit,
 ) = runComposeUiTest {
     val hosts = seededHosts()
@@ -352,6 +355,7 @@ internal fun runMobileShell(
                                 deps = AppDependencies(
                                     hosts = hosts, snippets = snippets, tunnels = tunnels,
                                     runbooks = mobileRunbooks, runbookRunner = runner,
+                                    keepAlivePower = keepAlivePower,
                                 ),
                                 state = state,
                                 sessions = sessions,

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/FakeKeepAlivePower.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/FakeKeepAlivePower.kt
@@ -1,0 +1,39 @@
+package app.skerry.ui.mobile
+
+import app.skerry.ui.keepalive.KeepAlivePower
+import app.skerry.ui.keepalive.KeepAliveVendor
+
+/** A device whose power settings the test owns. */
+internal class FakeKeepAlivePower(
+    override val vendor: KeepAliveVendor,
+    override val manufacturer: String = "TestCo",
+    /** false replays the system refusing the background service start that carries the change. */
+    private val delivers: Boolean = true,
+) : KeepAlivePower {
+
+    var exempt = false
+    var batteryPagesOpened = 0
+    var autostartPagesOpened = 0
+    var detailPagesOpened = 0
+
+    override var wakeLockEnabled: Boolean = false
+
+    override fun setWakeLockEnabled(enabled: Boolean): Boolean {
+        wakeLockEnabled = enabled
+        return delivers
+    }
+
+    override fun isExemptFromBatteryOptimization(): Boolean = exempt
+
+    override fun openBatteryOptimizationSettings() {
+        batteryPagesOpened++
+    }
+
+    override fun openAutostartSettings() {
+        autostartPagesOpened++
+    }
+
+    override fun openAppDetailsSettings() {
+        detailPagesOpened++
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileBiometricToggleTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileBiometricToggleTest.kt
@@ -126,8 +126,13 @@ class MobileBiometricToggleTest {
 
 private const val DEVICE = "test-device"
 
-/** An unlocked vault that holds no records and exports a real data key — all enrolment needs of it. */
-private class UnlockedVault(private val dataKey: DataKey) : Vault {
+/**
+ * An unlocked vault that holds no records and exports a real data key — all enrolment needs of it.
+ *
+ * Shared with [MobileSettingLinkRowTest], which needs a vault only so the Security screen builds a
+ * controller and its rows come alive.
+ */
+internal class UnlockedVault(private val dataKey: DataKey) : Vault {
     override fun exists(): Boolean = true
     override val isUnlocked: Boolean = true
     override fun create(password: CharArray) = Unit

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileKeepAliveScreenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileKeepAliveScreenTest.kt
@@ -1,0 +1,283 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertHasNoClickAction
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.filter
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import app.skerry.ui.app.LocalKeepAlivePower
+import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.keepalive_autostart
+import app.skerry.ui.generated.resources.keepalive_battery
+import app.skerry.ui.generated.resources.keepalive_battery_off
+import app.skerry.ui.generated.resources.keepalive_battery_on
+import app.skerry.ui.generated.resources.keepalive_device
+import app.skerry.ui.generated.resources.keepalive_open
+import app.skerry.ui.generated.resources.keepalive_recents
+import app.skerry.ui.generated.resources.keepalive_title
+import app.skerry.ui.generated.resources.keepalive_vendor_samsung
+import app.skerry.ui.generated.resources.keepalive_wakelock
+import app.skerry.ui.generated.resources.keepalive_wakelock_deferred
+import app.skerry.ui.keepalive.KeepAlivePower
+import app.skerry.ui.keepalive.KeepAliveVendor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The keep-alive screen against a fake device.
+ *
+ * What is worth pinning here is everything the original of this feature got wrong: a switch that
+ * changes nothing outside the composition, a status line read once and never again after the person
+ * has been sent to a system page to change it, and rows offering to open a page the device does not
+ * have.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobileKeepAliveScreenTest {
+
+    @Test
+    fun theWakeLockSwitchWritesThroughToTheDevice() {
+        val power = FakeKeepAlivePower(KeepAliveVendor.Samsung)
+        keepAliveScreen(power) {
+            onSwitch().assertIsOff()
+            onSwitch().performClick()
+            assertTrue(power.wakeLockEnabled, "the switch must reach the device, not just the UI state")
+            onSwitch().assertIsOn()
+            onSwitch().performClick()
+            assertFalse(power.wakeLockEnabled)
+        }
+    }
+
+    /** The switch shows what the device already holds, not a fresh default, when the screen opens. */
+    @Test
+    fun theSwitchOpensOnTheStoredValue() {
+        val power = FakeKeepAlivePower(KeepAliveVendor.Samsung).apply { wakeLockEnabled = true }
+        keepAliveScreen(power) { onSwitch().assertIsOn() }
+    }
+
+    @Test
+    fun theBatteryRowOpensTheSystemList() {
+        val power = FakeKeepAlivePower(KeepAliveVendor.Samsung)
+        keepAliveScreen(power) {
+            // Battery is the first of the link rows on every device.
+            onAllNodesWithText(string(Res.string.keepalive_open))[0].performScrollTo().performClick()
+            assertEquals(1, power.batteryPagesOpened)
+            assertEquals(0, power.autostartPagesOpened)
+            assertEquals(0, power.detailPagesOpened)
+        }
+    }
+
+    /**
+     * A ROM with no autostart list gets no autostart row: the button behind it can only open this
+     * app's details page, which is not what the row would be promising.
+     */
+    @Test
+    fun theAutostartRowIsDrawnOnlyForARomThatHasOne() {
+        keepAliveScreen(FakeKeepAlivePower(KeepAliveVendor.Xiaomi)) {
+            onNodeWithText(string(Res.string.keepalive_autostart)).performScrollTo().assertIsDisplayed()
+            assertEquals(2, linkCount())
+        }
+        keepAliveScreen(FakeKeepAlivePower(KeepAliveVendor.Samsung)) {
+            assertEquals(0, onAllNodesWithText(string(Res.string.keepalive_autostart)).fetchSemanticsNodes().size)
+            assertEquals(1, linkCount())
+        }
+    }
+
+    /** And it opens that page, not one of the other two the screen also knows how to open. */
+    @Test
+    fun theAutostartRowOpensTheRomsOwnPage() {
+        val power = FakeKeepAlivePower(KeepAliveVendor.Xiaomi)
+        keepAliveScreen(power) {
+            onAllNodesWithText(string(Res.string.keepalive_open))[1].performScrollTo().performClick()
+            assertEquals(1, power.autostartPagesOpened)
+            assertEquals(0, power.batteryPagesOpened)
+            assertEquals(0, power.detailPagesOpened)
+        }
+    }
+
+    /**
+     * The recents steps live in the ROM's own security app and in the task switcher, neither of
+     * which this app can open. A button landing on the app details page under those words would be
+     * a lie, so the row offers none.
+     */
+    @Test
+    fun theRecentsRowOffersNothingToOpen() {
+        val power = FakeKeepAlivePower(KeepAliveVendor.Samsung)
+        keepAliveScreen(power) {
+            onNodeWithText(string(Res.string.keepalive_recents)).performScrollTo()
+                .assertIsDisplayed().assertHasNoClickAction()
+            assertEquals(1, linkCount(), "battery is the only row with a page behind it on a Samsung")
+        }
+    }
+
+    /**
+     * The whole row carries the click, not the action word alone: a bare word is under the 24dp
+     * target floor, and a clickable leaf swallows the row's label into its own merged node, leaving
+     * a screen reader with identical "Open" stops it cannot tell apart.
+     */
+    @Test
+    fun theActionAndItsLabelAreOneStop() {
+        val power = FakeKeepAlivePower(KeepAliveVendor.Samsung)
+        keepAliveScreen(power) {
+            onNodeWithText(string(Res.string.keepalive_battery)).performScrollTo().assertHasClickAction()
+        }
+    }
+
+    /**
+     * A refused hand-off to the running service must not leave the switch reading "on" over sessions
+     * that never got the lock.
+     */
+    @Test
+    fun aChangeTheRunningSessionDidNotGetIsSaidSo() {
+        keepAliveScreen(FakeKeepAlivePower(KeepAliveVendor.Samsung, delivers = false)) {
+            assertEquals(0, deferredNotes())
+            onSwitch().performClick()
+            onNodeWithText(string(Res.string.keepalive_wakelock_deferred)).performScrollTo()
+                .assertIsDisplayed()
+                // Drawn for the eye only: read out as well, the sentence would be heard twice, once
+                // from this line and once from the announcer that carries it.
+                .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.HideFromAccessibility))
+            // And it does reach someone who is not looking at the screen.
+            onNodeWithContentDescription(string(Res.string.keepalive_wakelock_deferred)).assertIsDisplayed()
+        }
+        keepAliveScreen(FakeKeepAlivePower(KeepAliveVendor.Samsung)) {
+            onSwitch().performClick()
+            assertEquals(0, deferredNotes(), "the change reached the session; there is nothing to warn about")
+        }
+    }
+
+    /**
+     * The exemption is granted in a system page we navigated away to, so the status has to be read
+     * again on the way back. Read once at composition, the screen keeps telling a person who has
+     * just allowed it that the system may still suspend the app.
+     */
+    @Test
+    fun theBatteryStatusIsReadAgainWhenTheScreenComesBack() {
+        val power = FakeKeepAlivePower(KeepAliveVendor.Samsung)
+        val owner = TestLifecycleOwner()
+        keepAliveScreen(power, owner) {
+            onNodeWithText(string(Res.string.keepalive_battery_off)).performScrollTo().assertIsDisplayed()
+            // What the trip to the system page changes.
+            power.exempt = true
+            runOnIdle { owner.registry.currentState = Lifecycle.State.RESUMED }
+            waitForIdle()
+            onNodeWithText(string(Res.string.keepalive_battery_on)).performScrollTo().assertIsDisplayed()
+        }
+    }
+
+    /** Preview/offscreen: the screen draws, and nothing on it pretends to be configurable. */
+    @Test
+    fun withoutAPowerHookEveryRowIsInert() {
+        keepAliveScreen(power = null) {
+            assertEquals(0, linkCount())
+            onSwitch().performClick()
+            onSwitch().assertIsOff()
+            assertEquals(
+                0,
+                onAllNodesWithText(string(Res.string.keepalive_device, "")).fetchSemanticsNodes().size,
+                "no device to name, so no dangling \"Detected: \" line",
+            )
+        }
+    }
+
+    /**
+     * `Build.MANUFACTURER` is whatever the firmware wrote, and a custom ROM writes what it likes. The
+     * name is drawn in the middle of a list of instructions, so a bidi override in it would rewrite
+     * the lines around it.
+     */
+    @Test
+    fun anUnnamedFamilyDrawsASanitizedManufacturer() {
+        val raw = "Ace\u202Ecorp"
+        keepAliveScreen(FakeKeepAlivePower(KeepAliveVendor.Other, manufacturer = raw)) {
+            onNodeWithText(string(Res.string.keepalive_device, untrustedLabel(raw)))
+                .performScrollTo().assertIsDisplayed()
+            assertEquals(
+                0,
+                onAllNodesWithText(string(Res.string.keepalive_device, raw)).fetchSemanticsNodes().size,
+                "the raw manufacturer string reached the screen unfiltered",
+            )
+        }
+    }
+
+    /**
+     * And it draws with no lifecycle owner at all. `LocalLifecycleOwner` has no default value, so a
+     * screen that reads it unconditionally throws in the offscreen mobile renderer, which provides
+     * none — the More tab and this route would stop producing a PNG.
+     */
+    @Test
+    fun theScreenDrawsWithoutALifecycleOwner() {
+        val state = MobileDesignState()
+        runForm({ MobileKeepAliveScreen(state) }) {
+            onNodeWithText(string(Res.string.keepalive_title)).assertIsDisplayed()
+        }
+    }
+
+    /** With a known one, the line names the family rather than the raw manufacturer string. */
+    @Test
+    fun theDeviceLineNamesTheDetectedFamily() {
+        keepAliveScreen(FakeKeepAlivePower(KeepAliveVendor.Samsung)) {
+            val expected = string(Res.string.keepalive_device, string(Res.string.keepalive_vendor_samsung))
+            onNodeWithText(expected).performScrollTo().assertIsDisplayed()
+        }
+    }
+
+    private fun ComposeUiTest.deferredNotes() =
+        onAllNodesWithText(string(Res.string.keepalive_wakelock_deferred)).fetchSemanticsNodes().size
+
+    private fun ComposeUiTest.onSwitch() =
+        onNodeWithContentDescription(string(Res.string.keepalive_wakelock)).performScrollTo()
+
+    /** The "Open" words that actually carry a click — an inert row draws the word without one. */
+    private fun ComposeUiTest.linkCount() =
+        onAllNodesWithText(string(Res.string.keepalive_open)).filter(hasClickAction()).fetchSemanticsNodes().size
+
+    private fun keepAliveScreen(
+        power: KeepAlivePower?,
+        owner: TestLifecycleOwner = TestLifecycleOwner(),
+        body: ComposeUiTest.() -> Unit,
+    ) {
+        // Hoisted out of the composable: built inside, a recomposition would hand the screen a new one.
+        val state = MobileDesignState()
+        runForm({
+            CompositionLocalProvider(
+                LocalLifecycleOwner provides owner,
+                LocalKeepAlivePower provides power,
+            ) {
+                MobileKeepAliveScreen(state)
+            }
+        }) { body() }
+    }
+}
+
+/** A lifecycle the test drives itself, to replay the return from a system settings page. */
+private class TestLifecycleOwner : LifecycleOwner {
+    val registry: LifecycleRegistry = LifecycleRegistry.createUnsafe(this)
+    override val lifecycle: Lifecycle get() = registry
+
+    init {
+        // Started, not resumed: the resume is the event under test.
+        registry.currentState = Lifecycle.State.STARTED
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileMoreKeepAliveRowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileMoreKeepAliveRowTest.kt
@@ -1,0 +1,69 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import app.skerry.ui.app.MobileRoute
+import app.skerry.ui.app.MobileTab
+import app.skerry.ui.app.UiTags
+import app.skerry.ui.desktop.onScreen
+import app.skerry.ui.desktop.runMobileShell
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.keepalive_exempt
+import app.skerry.ui.generated.resources.keepalive_not_exempt
+import app.skerry.ui.generated.resources.keepalive_title
+import app.skerry.ui.keepalive.KeepAliveVendor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The More hub's keep-alive row, which is the whole of the feature's platform gate: everything the
+ * screen behind it configures is Doze and OEM task killers, so on a build with no
+ * [app.skerry.ui.keepalive.KeepAlivePower] behind it the row would push a screen whose every
+ * control is inert.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobileMoreKeepAliveRowTest {
+
+    @Test
+    fun theRowIsAbsentWhereNothingSuppliesThePower() = runMobileShell {
+        openMore()
+        assertEquals(
+            0,
+            onAllNodesWithText(string(Res.string.keepalive_title)).fetchSemanticsNodes().size,
+            "desktop and the offscreen renderer supply no power hook, so there is nothing to configure",
+        )
+    }
+
+    @Test
+    fun theRowOpensTheScreenAndReportsTheExemption() {
+        val power = FakeKeepAlivePower(KeepAliveVendor.Samsung)
+        runMobileShell(keepAlivePower = power) {
+            openMore()
+            onNodeWithText(string(Res.string.keepalive_not_exempt)).performScrollTo().assertIsDisplayed()
+            onNodeWithText(string(Res.string.keepalive_title)).performScrollTo().performClick()
+            onScreen(UiTags.mobileScreen(MobileRoute.KeepAlive)).assertIsDisplayed()
+        }
+    }
+
+    /** An exempt device says so, so the row is not a permanent warning nobody can clear. */
+    @Test
+    fun anExemptDeviceIsReportedAsOne() {
+        val power = FakeKeepAlivePower(KeepAliveVendor.Samsung).apply { exempt = true }
+        runMobileShell(keepAlivePower = power) {
+            openMore()
+            onNodeWithText(string(Res.string.keepalive_exempt)).performScrollTo().assertIsDisplayed()
+        }
+    }
+
+    private fun ComposeUiTest.openMore() {
+        onNodeWithTag(UiTags.mobileTab(MobileTab.More)).performClick()
+        waitForIdle()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileSettingLinkRowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileSettingLinkRowTest.kt
@@ -1,0 +1,108 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertHasNoClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.initializeVaultCrypto
+import app.skerry.ui.app.LocalVault
+import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.settings_change
+import app.skerry.ui.generated.resources.settings_change_pw_title
+import app.skerry.ui.generated.resources.settings_security_master_password
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The settings row that is a place to go rather than a switch, shared by the Security and keep-alive
+ * screens.
+ *
+ * Two properties are worth pinning because both were wrong in the hand-rolled copies this replaced:
+ * the click belongs to the whole row (a bare action word is under the 24dp target floor, and a
+ * clickable leaf takes the row's label into its own merged node, leaving a screen reader with
+ * "Change, button" and no idea what it changes), and a row with nothing behind it must lose the
+ * click, not merely dim the word.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobileSettingLinkRowTest {
+
+    @Test
+    fun theWholeRowCarriesTheClickAndItsLabel() {
+        var taps = 0
+        runForm({ MobileSettingLinkRow(LABEL, SUBTITLE, ACTION, onAction = { taps++ }) }) {
+            // Found by the label, clicked at the row's centre — the word alone is not the target.
+            onNodeWithText(LABEL).assertHasClickAction().performClick()
+            assertEquals(1, taps)
+            onNodeWithText(SUBTITLE).assertIsDisplayed()
+            onNodeWithText(ACTION).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun aRowWithNothingBehindItTakesNoClick() {
+        runForm({ MobileSettingLinkRow(LABEL, SUBTITLE, ACTION, onAction = null) }) {
+            onNodeWithText(LABEL).assertHasNoClickAction()
+            onNodeWithText(ACTION).assertHasNoClickAction()
+        }
+    }
+
+    /** The note variant: a setting that lives in the firmware has no action word to offer at all. */
+    @Test
+    fun theNoteRowOffersNoActionWord() {
+        runForm({ MobileSettingNoteRow(LABEL, SUBTITLE) }) {
+            onNodeWithText(LABEL).assertIsDisplayed().assertHasNoClickAction()
+            onNodeWithText(SUBTITLE).assertIsDisplayed()
+        }
+    }
+
+    /**
+     * The Security screen draws its master-password row through the same primitive, and without a
+     * vault behind it the row has to be inert rather than open a dialog over a locked app.
+     */
+    @Test
+    fun theSecurityScreenRowIsInertWithoutAVault() {
+        val state = MobileDesignState()
+        runForm({ MobileSecurityScreen(state) }) {
+            val label = string(Res.string.settings_security_master_password)
+            onNodeWithText(label).performScrollTo().assertIsDisplayed().assertHasNoClickAction()
+            assertEquals(
+                1,
+                onAllNodesWithText(string(Res.string.settings_change)).fetchSemanticsNodes().size,
+                "the action word is drawn, only dimmed and unclickable",
+            )
+        }
+    }
+
+    /**
+     * And with a vault behind it the same row reaches the handler it is named for: the conversion to
+     * the shared primitive is the moment a rewired click would go unnoticed.
+     */
+    @Test
+    fun theSecurityScreenRowOpensThePasswordDialog() {
+        val vault = UnlockedVault(runBlocking { initializeVaultCrypto(); IonspinVaultCrypto().newDataKey() })
+        val state = MobileDesignState()
+        runForm({
+            CompositionLocalProvider(LocalVault provides vault) { MobileSecurityScreen(state) }
+        }) {
+            onNodeWithText(string(Res.string.settings_security_master_password)).performScrollTo().performClick()
+            waitForIdle()
+            onNodeWithText(string(Res.string.settings_change_pw_title)).assertIsDisplayed()
+        }
+    }
+
+    private companion object {
+        const val LABEL = "Autostart"
+        const val SUBTITLE = "Allow the app to start on its own"
+        const val ACTION = "Open"
+    }
+}


### PR DESCRIPTION
A foreground service keeps the process, not the CPU. With the screen off the device still
suspends between wakeups, the SSH keepalive misses its interval and the server drops a session
that was otherwise fine; an OEM ROM kills an app that is on no autostart whitelist on its own
schedule regardless. Every remedy for that lives outside the app, so a new Android screen —
More → Background & lock screen — collects them in one place.

## What it does

- **Wake lock.** A partial wake lock the keep-alive service holds while sessions are open and the
  switch is on. Off by default: the cost is battery. Toggling it reaches the sessions already
  running; when the system refuses the service start, the screen says the value was saved and
  takes effect on the next connection rather than reading "on" over sessions without the lock.
- **Battery optimisation.** Opens the system list of battery-optimised apps and shows whether this
  app is currently exempt. The list, not the one-tap dialog: that intent needs
  `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`, which Google Play gates behind a declaration form.
- **Autostart.** Opens the ROM's own autostart page for the families that have one (Xiaomi/HyperOS,
  Huawei/Honor, Oppo/realme/OnePlus, vivo/iQOO), by explicit component and only where the system
  itself installed that package. The row is absent on devices with no such page.
- **Recents.** The lock-in-recents and lock-screen steps live in the firmware and have no intent,
  so they are spelled out per vendor instead of linked.

Android only — the More row and the route appear where a `KeepAlivePower` is bound and nowhere
else. The desktop build is unchanged.

## Testing

30 tests, each confirmed failing with its fix reverted:

- `WakeLockGateTest` — acquire/release across session counts and the setting, no double acquire,
  release without a lock, a null `PowerManager`.
- `KeepAliveAutostartPagesTest` — the manifest `<queries>` and the component table agree in both
  directions, and a vendor advertises an autostart page iff it has one.
- `KeepAliveVendorTest` — manufacturer strings to vendors.
- `MobileKeepAliveScreenTest`, `MobileSettingLinkRowTest`, `MobileMoreKeepAliveRowTest` — the rows
  that appear per vendor, the toggle path including the deferred notice, the exemption status and
  its announcement, and that the screen draws with no lifecycle owner (the offscreen renderer
  provides none).

Strings in en, ru and zh.

## Verify by hand

More → Background & lock screen on an Android device. The switch turns the wake lock on for open
sessions; the battery row opens the system list and its subtitle flips after granting the
exemption; the autostart row appears only on a ROM that has that page. Connect a session, lock the
screen, leave it for several minutes — with the exemption granted it should still be alive.

## Not verified

No real device, no TalkBack pass, and the autostart component table was checked against the
manifest and itself, not against a live Xiaomi/Huawei/Oppo/vivo ROM.

Supersedes #357, which proposed the same four steps but wired none of them up.
