### PR TITLE
Keep a late session loss from stranding a closed pane

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -248,6 +248,23 @@ class ConnectionController(
     /** Takes the pending reveal request, clearing it — a request is acted on exactly once. */
     fun takeRevealRequest(): String? = pendingRevealPath?.also { pendingRevealPath = null }
 
+    // Every transition of [uiState] and of the session's fields runs under this lock, stamped with
+    // [sessionGeneration]. They contend from every side: the two publishers ([connect] and
+    // [attachSession]), a handshake finishing in [establishSession], the retry loop in
+    // [startReconnect], a loss from the session watcher, the vault lock's
+    // [clearReconnectCredentials], and the user's [disconnect]. None of them is inline — the loss
+    // is dispatched onto [scope], the handshake runs on its own coroutine — and neither a state
+    // check nor job cancellation can stop one already under way: the loss used to read "still
+    // Connected" and then write [ConnectionUiState.Disconnected] over the [ConnectionUiState.Form]
+    // a close had just set, leaving a pane [connect] silently refuses to start from (issue #353).
+    // So the check and the assignment it guards live in one block, and a writer whose stamp is
+    // stale writes nothing — the shape [PingController] already uses.
+    private val lock = Any()
+
+    // Which session the controller owns. Every teardown retires the number, so a writer stamped
+    // with an earlier one belongs to a session that is already gone and is dropped.
+    private var sessionGeneration = 0
+
     private var connectJob: Job? = null
     // Target/auth of the last connect — used by auto-reconnect after a drop (reconnects to the same target).
     private var lastTarget: SshTarget? = null
@@ -287,17 +304,21 @@ class ConnectionController(
      * auto-reconnect after a drop (reconnect carries no such callback).
      */
     fun connect(target: SshTarget, auth: SshAuth, onConnected: ((TerminalScreenState) -> Unit)? = null) {
-        // Only starts from the form: while a connect is in progress or a session is open, a repeat
-        // connect is ignored — otherwise a scope/connection could leak.
-        if (uiState !is ConnectionUiState.Form) return
-        supportsSftp = target.connectionType.carriesSftp
-        lastTarget = target
-        lastAuth = auth
-        pendingOnConnected = onConnected
-        uiState = ConnectionUiState.Connecting
-        connectJob = scope.launch {
+        // The session this connect opens; everything it writes later is stamped with it (see [lock]).
+        val generation = synchronized(lock) {
+            // Only starts from the form: while a connect is in progress or a session is open, a repeat
+            // connect is ignored — otherwise a scope/connection could leak.
+            if (uiState !is ConnectionUiState.Form) return
+            supportsSftp = target.connectionType.carriesSftp
+            lastTarget = target
+            lastAuth = auth
+            pendingOnConnected = onConnected
+            uiState = ConnectionUiState.Connecting
+            sessionGeneration
+        }
+        val job = scope.launch {
             try {
-                establishSession(target, auth)
+                establishSession(target, auth, generation)
             } catch (e: CancellationException) {
                 // disconnect() fired mid-connect: the half-open connection is already closed inside
                 // establishSession; uiState was set to Form by disconnect() itself.
@@ -306,23 +327,32 @@ class ConnectionController(
                 // The serial transport wraps its typed failure into SshConnectionException, so the
                 // cause carries the reason the view localizes.
                 val serial = e as? SerialUnavailableException ?: e.cause as? SerialUnavailableException
-                // A throw after Connected was published (onConnected action, watcher setup) has
-                // already announced the session to the keep-alive bridge — retract it.
-                notifyKeepAliveEnded()
-                uiState = ConnectionUiState.Error(
-                    // Transport text is diagnostics only: the view shows a localized base and keeps
-                    // this as a parenthetical detail (sshj/okio messages are always English). It is
-                    // still the server's own words, so it crosses the same sanitising boundary the
-                    // reconnect banner uses.
-                    message = serverFailureDetail(e).orEmpty(),
-                    moshReason = (e as? MoshSetupException)?.reason,
-                    moshDetail = (e as? MoshSetupException)?.detail,
-                    serialProblem = serial?.problem,
-                    serialDetail = serial?.detail,
-                    hostKeyRefusal = (e as? SshHostKeyRejectedException)?.refusal,
-                    hostKeyRefusalOnHop = (e as? SshHostKeyRejectedException)?.hop == true,
-                )
+                synchronized(lock) {
+                    // The pane was closed while this connect was failing: its form is the truth now.
+                    if (generation != sessionGeneration) return@launch
+                    // A throw after Connected was published (onConnected action, watcher setup) has
+                    // already announced the session to the keep-alive bridge — retract it.
+                    notifyKeepAliveEnded()
+                    uiState = ConnectionUiState.Error(
+                        // Transport text is diagnostics only: the view shows a localized base and
+                        // keeps this as a parenthetical detail (sshj/okio messages are always
+                        // English). It is still the server's own words, so it crosses the same
+                        // sanitising boundary the reconnect banner uses.
+                        message = serverFailureDetail(e).orEmpty(),
+                        moshReason = (e as? MoshSetupException)?.reason,
+                        moshDetail = (e as? MoshSetupException)?.detail,
+                        serialProblem = serial?.problem,
+                        serialDetail = serial?.detail,
+                        hostKeyRefusal = (e as? SshHostKeyRejectedException)?.refusal,
+                        hostKeyRefusalOnHop = (e as? SshHostKeyRejectedException)?.hop == true,
+                    )
+                }
             }
+        }
+        synchronized(lock) {
+            // Still this session's connect? If a [disconnect] retired it while the job was being
+            // launched, its teardown has already run and the job only needs stopping.
+            if (generation == sessionGeneration) connectJob = job else job.cancel()
         }
     }
 
@@ -364,8 +394,12 @@ class ConnectionController(
      * terminal, transitions to [ConnectionUiState.Connected], and subscribes the drop observer. On
      * any error, closes the half-open connection and rethrows (the caller decides: show [Error] or
      * retry a reconnect attempt). Used by both the initial [connect] and auto-reconnect.
+     *
+     * Publishing is all-or-nothing under [lock] and only for [generation]: cancellation is
+     * cooperative, and everything from the last [ensureActive] to the transition is synchronous, so
+     * only the stamp can still stop a handshake a [disconnect] has overtaken.
      */
-    private suspend fun establishSession(target: SshTarget, auth: SshAuth) {
+    private suspend fun establishSession(target: SshTarget, auth: SshAuth, generation: Int) {
         var conn: SshConnection? = null
         try {
             val opened = transport.connect(target, auth)
@@ -374,69 +408,120 @@ class ConnectionController(
             val channel = opened.openShell()
             coroutineContext.ensureActive()
             val sScope = newSessionScope()
-            connection = conn
-            // IMPORTANT: the channel must be set BEFORE uiState = Connected — the status bar's
-            // reaction to that transition calls openThroughput(), which requires a live shellChannel
-            // (otherwise it throws).
-            shellChannel = channel
-            cipher = conn.cipher
-            serverVersion = conn.serverVersion
-            sessionScope = sScope
             // Command history for autocomplete: load for this host and attach a snapshot-persist
             // hook on every committed command (runs on the controller's IO scope, not the UI thread).
             val historyKey = terminalHistoryKey(
                 target.connectionType.name, target.username, target.host, target.port,
             )
-            this.historyKey = historyKey
             val terminal = newTerminal(target, auth, channel, sScope, historyKey)
-            // Keep-alive per the profile's cadence (0 = off, SSH-only): pings run from the moment
-            // the session exists — not lazily from the status bar — so an idle session behind a NAT
-            // stays alive even with no UI polling it. Created BEFORE Connected (like shellChannel)
-            // so the status bar's openPing() sees it on the transition. Doubles as the RTT source.
-            // Container sessions ride an SSH connection, so they keep the profile's cadence too.
-            if (target.connectionType.carriedBySsh && target.keepAliveSeconds > 0) {
-                ping = PingController(
-                    measure = { opened.measureRoundTrip() },
-                    scope = scope,
-                    pollIntervalMillis = target.keepAliveSeconds * 1_000L,
-                    onDead = {
-                        // Dead link (consecutive keepalives unanswered): force-close the shell
-                        // channel so the loss flows through the regular drop path (Closed without
-                        // EOF -> auto-reconnect) now, not after minutes of frozen terminal
-                        // waiting out the TCP timeout. NonCancellable like the other teardown
-                        // launches: the close must not be lost if the scope dies at that moment.
-                        scope.launch(NonCancellable) { runCatching { channel.close() } }
-                    },
-                ).also { it.start() }
+            val session = OpenedSession(target, opened, channel, sScope, historyKey, terminal)
+            var onConnected: ((TerminalScreenState) -> Unit)? = null
+            val published = synchronized(lock) {
+                if (generation != sessionGeneration) {
+                    false // the pane was closed under us
+                } else {
+                    publishSession(session)
+                    // One-shot action for the first connect (Run on host): taken and cleared BEFORE a
+                    // possible drop, so a reconnect through this same establishSession doesn't repeat
+                    // it. Run below, outside the lock — it is caller code and reaches the terminal.
+                    onConnected = pendingOnConnected
+                    pendingOnConnected = null
+                    true
+                }
             }
-            if (target.connectionType == ConnectionType.MOSH) {
-                // Mosh needs no keep-alive traffic (the protocol heartbeats every 3s on its own)
-                // and must not be declared dead (it survives outages/roaming by design), so:
-                // fixed poll cadence, no onDead. measureRoundTrip() only reads the smoothed RTT
-                // mosh already measured — the poll itself sends nothing.
-                ping = PingController(
-                    measure = { opened.measureRoundTrip() },
-                    scope = scope,
-                    pollIntervalMillis = MOSH_RTT_POLL_MILLIS,
-                ).also { it.start() }
+            if (!published) {
+                // Nothing of this session reached the controller, so dropping it is just releasing
+                // what this attempt opened.
+                sScope.cancel()
+                closeConnectionQuietly(conn)
+                return
             }
-            uiState = ConnectionUiState.Connected(terminal)
-            // Tell the platform keep-alive bridge that a session is now open (Android runs a
-            // foreground service while sessions exist; no-op on desktop). Done after Connected so
-            // the notification/keep-alive starts exactly when the session is usable.
-            notifyKeepAliveStarted(target.host)
-            // One-shot action for the first connect (Run on host): taken and cleared BEFORE a
-            // possible drop, so a reconnect through this same establishSession doesn't repeat it.
-            pendingOnConnected?.let { action -> pendingOnConnected = null; action(terminal) }
-            watchForSessionLoss(terminal, sScope)
+            onConnected?.invoke(terminal)
+            watchForSessionLoss(terminal, sScope, generation)
         } catch (e: Exception) {
-            // A throw after the session fields are published (e.g. from the onConnected action)
-            // must not leave a half-established session — keep-alive loop, session scope, open
-            // socket — behind an Error state: reuse the disconnect teardown. Before that point
-            // only the local connection exists and just needs closing.
-            if (connection != null) releaseSessionResources() else conn?.let(::closeConnectionQuietly)
+            // A throw after the session was published (e.g. from the onConnected action) must not
+            // leave a half-established session — keep-alive loop, session scope, open socket —
+            // behind an Error state: reuse the disconnect teardown, under the lock that owns those
+            // fields. Before the publication, and for a session a [disconnect] has already retired,
+            // only this attempt's own connection needs closing.
+            val ours = synchronized(lock) {
+                val published = generation == sessionGeneration && connection != null
+                if (published) releaseSessionResources()
+                published
+            }
+            if (!ours) conn?.let(::closeConnectionQuietly)
             throw e
         }
+    }
+
+    /**
+     * Everything one handshake produced, before the controller adopted any of it. Grouped so the
+     * publication is one assignment and the abandoned attempt is one release ([establishSession]).
+     */
+    private class OpenedSession(
+        val target: SshTarget,
+        val conn: SshConnection,
+        val channel: ShellChannel,
+        val scope: CoroutineScope,
+        val historyKey: String,
+        val terminal: TerminalScreenState,
+    )
+
+    /**
+     * Writes this session into the controller's fields and moves the pane to
+     * [ConnectionUiState.Connected]. Caller holds [lock] and has checked the generation: every
+     * field here is one [releaseSessionResources] clears, so the two must never interleave.
+     */
+    private fun publishSession(session: OpenedSession) {
+        val target = session.target
+        val conn = session.conn
+        val channel = session.channel
+        val terminal = session.terminal
+        connection = conn
+        // IMPORTANT: the channel must be set BEFORE uiState = Connected — the status bar's
+        // reaction to that transition calls openThroughput(), which requires a live shellChannel
+        // (otherwise it throws).
+        shellChannel = channel
+        cipher = conn.cipher
+        serverVersion = conn.serverVersion
+        sessionScope = session.scope
+        historyKey = session.historyKey
+        // Keep-alive per the profile's cadence (0 = off, SSH-only): pings run from the moment
+        // the session exists — not lazily from the status bar — so an idle session behind a NAT
+        // stays alive even with no UI polling it. Created BEFORE Connected (like shellChannel)
+        // so the status bar's openPing() sees it on the transition. Doubles as the RTT source.
+        // Container sessions ride an SSH connection, so they keep the profile's cadence too.
+        if (target.connectionType.carriedBySsh && target.keepAliveSeconds > 0) {
+            ping = PingController(
+                measure = { conn.measureRoundTrip() },
+                scope = scope,
+                pollIntervalMillis = target.keepAliveSeconds * 1_000L,
+                onDead = {
+                    // Dead link (consecutive keepalives unanswered): force-close the shell
+                    // channel so the loss flows through the regular drop path (Closed without
+                    // EOF -> auto-reconnect) now, not after minutes of frozen terminal
+                    // waiting out the TCP timeout. NonCancellable like the other teardown
+                    // launches: the close must not be lost if the scope dies at that moment.
+                    scope.launch(NonCancellable) { runCatching { channel.close() } }
+                },
+            ).also { it.start() }
+        }
+        if (target.connectionType == ConnectionType.MOSH) {
+            // Mosh needs no keep-alive traffic (the protocol heartbeats every 3s on its own)
+            // and must not be declared dead (it survives outages/roaming by design), so:
+            // fixed poll cadence, no onDead. measureRoundTrip() only reads the smoothed RTT
+            // mosh already measured — the poll itself sends nothing.
+            ping = PingController(
+                measure = { conn.measureRoundTrip() },
+                scope = scope,
+                pollIntervalMillis = MOSH_RTT_POLL_MILLIS,
+            ).also { it.start() }
+        }
+        uiState = ConnectionUiState.Connected(terminal)
+        // Tell the platform keep-alive bridge that a session is now open (Android runs a
+        // foreground service while sessions exist; no-op on desktop). Done after Connected so
+        // the notification/keep-alive starts exactly when the session is usable.
+        notifyKeepAliveStarted(target.host)
     }
 
     /**
@@ -450,13 +535,9 @@ class ConnectionController(
      * hold two sessions, and the caller's would be silently orphaned.
      */
     fun attachSession(external: TerminalSession) {
-        if (uiState !is ConnectionUiState.Form) return
-        supportsSftp = false
-        isWatched = true
-        val sScope = newSessionScope()
-        sessionScope = sScope
-        attached = external
+        if (uiState !is ConnectionUiState.Form) return // cheap bail; the binding check is below
         val prefs = terminalPrefs()
+        val sScope = newSessionScope()
         val terminal = TerminalScreenState(
             external,
             sScope,
@@ -465,8 +546,22 @@ class ConnectionController(
             cursorBlink = prefs.cursorStyle.blink,
             clipboardWriteEnabled = prefs.clipboardWriteEnabled,
         )
-        uiState = ConnectionUiState.Connected(terminal)
-        watchForSessionLoss(terminal, sScope)
+        val generation = synchronized(lock) {
+            if (uiState !is ConnectionUiState.Form) {
+                // A connect or a loss got the form first: release what this attach opened, and
+                // nothing else — a refused attach leaves the caller's session to the caller
+                // (same contract as the cheap bail above), it does not close it on their behalf.
+                sScope.cancel()
+                return
+            }
+            supportsSftp = false
+            isWatched = true
+            sessionScope = sScope
+            attached = external
+            uiState = ConnectionUiState.Connected(terminal)
+            sessionGeneration
+        }
+        watchForSessionLoss(terminal, sScope, generation)
     }
 
     /**
@@ -584,22 +679,26 @@ class ConnectionController(
 
     /** Close the session (if any) and return to the form. Cancels any active connect and auto-reconnect. */
     fun disconnect() {
-        connectJob?.cancel()
-        connectJob = null
-        reconnectJob?.cancel()
-        reconnectJob = null
-        // Drop the secret reference right away (auth may carry a password/key) — don't hold it on
-        // the heap longer than the connection's lifetime.
-        lastAuth = null
-        lastTarget = null
-        // Cancelled before Connected — discard the not-yet-fired one-shot action (Run on host).
-        pendingOnConnected = null
-        // Stop pointing at the disconnected host: a palette opened later must not attribute its
-        // commands to a session that is gone.
-        historyKey = null
-        releaseSessionResources()
-        notifyKeepAliveEnded()
-        uiState = ConnectionUiState.Form
+        synchronized(lock) {
+            // Retires the session first, so anything still in flight for it writes nothing.
+            sessionGeneration++
+            connectJob?.cancel()
+            connectJob = null
+            reconnectJob?.cancel()
+            reconnectJob = null
+            // Drop the secret reference right away (auth may carry a password/key) — don't hold it on
+            // the heap longer than the connection's lifetime.
+            lastAuth = null
+            lastTarget = null
+            // Cancelled before Connected — discard the not-yet-fired one-shot action (Run on host).
+            pendingOnConnected = null
+            // Stop pointing at the disconnected host: a palette opened later must not attribute its
+            // commands to a session that is gone.
+            historyKey = null
+            releaseSessionResources()
+            notifyKeepAliveEnded()
+            uiState = ConnectionUiState.Form
+        }
     }
 
     /**
@@ -610,21 +709,28 @@ class ConnectionController(
      * no attempts, and the user reconnects manually after unlocking.
      */
     fun clearReconnectCredentials() {
-        val wasReconnecting = reconnectJob != null
-        reconnectJob?.cancel()
-        reconnectJob = null
-        lastAuth = null
-        lastTarget = null
-        // Lock also cancels the pending first-connect action (Run on host): a snippet command must
-        // not fire into the terminal if the handshake completes after the vault is already locked.
-        pendingOnConnected = null
-        // Cancelling a mid-flight auto-reconnect is a true end: the credentials are gone, so no
-        // path can ever bring this session back — retract the keep-alive (the cancelled loop never
-        // reaches its own exhaustion notify) and stop the pane claiming "reconnecting". A still-
-        // connected session is untouched: lock leaves the socket open by design (see doc above).
-        if (wasReconnecting && uiState !is ConnectionUiState.Connected) {
-            (uiState as? ConnectionUiState.Disconnected)?.let { uiState = it.copy(reconnecting = false) }
-            notifyKeepAliveEnded()
+        synchronized(lock) {
+            val wasReconnecting = reconnectJob != null
+            reconnectJob?.cancel()
+            reconnectJob = null
+            lastAuth = null
+            lastTarget = null
+            // Lock also cancels the pending first-connect action (Run on host): a snippet command must
+            // not fire into the terminal if the handshake completes after the vault is already locked.
+            pendingOnConnected = null
+            // Cancelling a mid-flight auto-reconnect is a true end: the credentials are gone, so no
+            // path can ever bring this session back — retract the keep-alive (the cancelled loop never
+            // reaches its own exhaustion notify) and stop the pane claiming "reconnecting". A still-
+            // connected session is untouched: lock leaves the socket open by design (see doc above).
+            if (wasReconnecting && uiState !is ConnectionUiState.Connected) {
+                // Retire the session as well: the cancelled attempt may already be past its last
+                // cancellation check, and without this its writes would put the pane back on a
+                // reconnect that can no longer happen. A live session is deliberately left alone
+                // (this branch never runs for one), so its own drop still reaches the watcher.
+                sessionGeneration++
+                (uiState as? ConnectionUiState.Disconnected)?.let { uiState = it.copy(reconnecting = false) }
+                notifyKeepAliveEnded()
+            }
         }
     }
 
@@ -635,14 +741,14 @@ class ConnectionController(
      * reached ONLY on a server-side drop, which is what distinguishes an unintended loss (->
      * auto-reconnect) from an intentional close (-> Form).
      */
-    private fun watchForSessionLoss(terminal: TerminalScreenState, sScope: CoroutineScope) {
+    private fun watchForSessionLoss(terminal: TerminalScreenState, sScope: CoroutineScope, generation: Int) {
         sScope.launch {
             val closed = terminal.state.first { it is TerminalState.Closed } as TerminalState.Closed
             // Dispatch loss handling onto the main [scope] — the same one [disconnect] runs on.
             // Otherwise onSessionLost would run on the session scope (Dispatchers.Default), racing
             // reconnectJob writes/cancels against disconnect on the UI thread. On one scope they're
             // serialized.
-            scope.launch { onSessionLost(terminal, closed.cleanExit) }
+            scope.launch { onSessionLost(terminal, closed.cleanExit, generation) }
         }
     }
 
@@ -652,44 +758,55 @@ class ConnectionController(
      * saved credentials and shows a neutral "Session closed". Otherwise (transport drop), starts
      * auto-reconnect to the last [lastTarget]/[lastAuth] — but ONLY for SSH; Telnet/Serial have no
      * reconnect (see below). Without saved target/credentials, stays in
-     * [ConnectionUiState.Disconnected] with no attempts. The Connected guard prevents re-entry.
+     * [ConnectionUiState.Disconnected] with no attempts. The Connected guard prevents re-entry;
+     * [generation] names the session this loss belongs to (see [lock]).
      */
-    private fun onSessionLost(frozen: TerminalScreenState, cleanExit: Boolean) {
-        if (uiState !is ConnectionUiState.Connected) return
-        releaseSessionResources()
-        if (cleanExit) {
-            // The user closed the shell themselves (`exit`) — close the session, no reconnect. Drop
-            // the secret (auth may carry a password/key): no point holding it, there won't be a new connect.
-            lastAuth = null
-            lastTarget = null
-            notifyKeepAliveEnded()
-            uiState = ConnectionUiState.Disconnected(frozen, reconnecting = false, attempt = 0, cleanExit = true)
-            return
+    private fun onSessionLost(frozen: TerminalScreenState, cleanExit: Boolean, generation: Int) {
+        synchronized(lock) {
+            // Not this session's loss any more: the pane was closed (or a previous loss was already
+            // handled) while this one was on its way here (see [lock]).
+            if (generation != sessionGeneration) return
+            // Belt and braces for the one publisher that has no target to reconnect to either way:
+            // [attachSession] stamps a watcher for a session it does not own.
+            if (uiState !is ConnectionUiState.Connected) return
+            sessionGeneration++
+            releaseSessionResources()
+            if (cleanExit) {
+                // The user closed the shell themselves (`exit`) — close the session, no reconnect. Drop
+                // the secret (auth may carry a password/key): no point holding it, there won't be a new connect.
+                lastAuth = null
+                lastTarget = null
+                notifyKeepAliveEnded()
+                uiState = ConnectionUiState.Disconnected(frozen, reconnecting = false, attempt = 0, cleanExit = true)
+                return
+            }
+            val target = lastTarget
+            val auth = lastAuth
+            if (target == null || auth == null) {
+                notifyKeepAliveEnded()
+                uiState = ConnectionUiState.Disconnected(frozen, reconnecting = false, attempt = 0)
+                return
+            }
+            // Auto-reconnect only for SSH. It doesn't make sense for Telnet/Serial: there's no
+            // authentication, and a "drop" there is usually the server closing the session or the
+            // device disappearing (cable unplugged / rig stopped) — silently reconnecting is pointless;
+            // the user connects again manually. Mosh is excluded too: the protocol itself survives
+            // outages and roaming (that's its point), so its session never "drops" on network loss —
+            // reaching here means the server shut down or the socket died, and a silent re-bootstrap
+            // would open a brand-new remote session behind the user's back.
+            if (!target.connectionType.carriedBySsh) {
+                lastAuth = null
+                lastTarget = null
+                notifyKeepAliveEnded()
+                uiState = ConnectionUiState.Disconnected(frozen, reconnecting = false, attempt = 0)
+                return
+            }
+            // Entering auto-reconnect: the session is NOT reported ended — the platform keep-alive
+            // (foreground service) must survive the retry window, or the reconnect itself dies with it.
+            // The retry carries the generation this loss just opened, so a [disconnect] during the
+            // retry window retires the whole loop rather than only cancelling its job.
+            startReconnect(frozen, target, auth, sessionGeneration)
         }
-        val target = lastTarget
-        val auth = lastAuth
-        if (target == null || auth == null) {
-            notifyKeepAliveEnded()
-            uiState = ConnectionUiState.Disconnected(frozen, reconnecting = false, attempt = 0)
-            return
-        }
-        // Auto-reconnect only for SSH. It doesn't make sense for Telnet/Serial: there's no
-        // authentication, and a "drop" there is usually the server closing the session or the
-        // device disappearing (cable unplugged / rig stopped) — silently reconnecting is pointless;
-        // the user connects again manually. Mosh is excluded too: the protocol itself survives
-        // outages and roaming (that's its point), so its session never "drops" on network loss —
-        // reaching here means the server shut down or the socket died, and a silent re-bootstrap
-        // would open a brand-new remote session behind the user's back.
-        if (!target.connectionType.carriedBySsh) {
-            lastAuth = null
-            lastTarget = null
-            notifyKeepAliveEnded()
-            uiState = ConnectionUiState.Disconnected(frozen, reconnecting = false, attempt = 0)
-            return
-        }
-        // Entering auto-reconnect: the session is NOT reported ended — the platform keep-alive
-        // (foreground service) must survive the retry window, or the reconnect itself dies with it.
-        startReconnect(frozen, target, auth)
     }
 
     /**
@@ -700,20 +817,33 @@ class ConnectionController(
      * observer on success). Once the limit is exhausted, stays in Disconnected with
      * `reconnecting=false`. Runs on the main [scope] (outlives the old session's teardown);
      * [disconnect] cancels [reconnectJob].
+     *
+     * Called with [lock] held (from [onSessionLost]): the [reconnectJob] assignment is one of the
+     * fields that lock owns, and [generation] must be the one read under it.
      */
-    private fun startReconnect(frozen: TerminalScreenState, target: SshTarget, auth: SshAuth) {
+    private fun startReconnect(
+        frozen: TerminalScreenState,
+        target: SshTarget,
+        auth: SshAuth,
+        generation: Int,
+    ) {
         reconnectJob = scope.launch {
             var attempt = 1
             var lastError: String? = null
             while (attempt <= maxReconnectAttempts) {
-                uiState = ConnectionUiState.Disconnected(frozen, reconnecting = true, attempt = attempt)
+                // The loop's writes have no suspension point in front of them, so cancelling
+                // [reconnectJob] cannot stop one already under way — only the stamp can (see [lock]).
+                synchronized(lock) {
+                    if (generation != sessionGeneration) return@launch
+                    uiState = ConnectionUiState.Disconnected(frozen, reconnecting = true, attempt = attempt)
+                }
                 delay(reconnectDelayMillis(attempt))
                 try {
-                    establishSession(target, auth)
+                    establishSession(target, auth, generation)
                     // Success: establishSession moved to Connected and resubscribed the observer.
                     // Null the job so a later vault lock doesn't read a completed reconnect as
                     // "reconnecting" (clearReconnectCredentials keys off it).
-                    reconnectJob = null
+                    synchronized(lock) { if (generation == sessionGeneration) reconnectJob = null }
                     return@launch
                 } catch (e: CancellationException) {
                     throw e
@@ -726,14 +856,17 @@ class ConnectionController(
                     attempt++
                 }
             }
-            notifyKeepAliveEnded() // reconnect gave up — now the session is truly over
-            reconnectJob = null
-            uiState = ConnectionUiState.Disconnected(
-                frozen,
-                reconnecting = false,
-                attempt = maxReconnectAttempts,
-                lastError = lastError,
-            )
+            synchronized(lock) {
+                if (generation != sessionGeneration) return@launch
+                notifyKeepAliveEnded() // reconnect gave up — now the session is truly over
+                reconnectJob = null
+                uiState = ConnectionUiState.Disconnected(
+                    frozen,
+                    reconnecting = false,
+                    attempt = maxReconnectAttempts,
+                    lastError = lastError,
+                )
+            }
         }
     }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/AttachedSessionTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/AttachedSessionTest.kt
@@ -154,6 +154,45 @@ class AttachedSessionTest {
         scope.cancel()
     }
 
+    /**
+     * The refusal above is also checked a second time, under the controller's lock: between the
+     * cheap bail and that check the pane's form can be taken by whoever asked first. The attach
+     * that loses must leave both the winner's session and its own caller's alone — an attach is
+     * refused, not adopted-then-dropped.
+     *
+     * Staged through `newSessionScope`, which the controller calls inside exactly that window.
+     */
+    @Test
+    fun `an attach that loses the form leaves the winning session on the pane`() = runTest {
+        val winner = WatchedSession()
+        val loser = WatchedSession()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        var steal = true
+        lateinit var controller: ConnectionController
+        controller = ConnectionController(
+            transport = NoTransport,
+            scope = scope,
+            newSessionScope = {
+                if (steal) {
+                    steal = false // the winner's own attach must get through
+                    controller.attachSession(winner)
+                }
+                CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+            },
+        )
+
+        controller.attachSession(loser)
+        advanceUntilIdle()
+
+        val state = assertIs<ConnectionUiState.Connected>(controller.uiState)
+        winner.emissions.emit("mine".encodeToByteArray())
+        advanceUntilIdle()
+        assertTrue(state.terminal.output.contains("mine"), "the pane kept the attach that lost the form")
+        assertFalse(loser.closed, "a refused attach must leave the caller's session alone")
+        assertFalse(winner.closed)
+        scope.cancel()
+    }
+
     @Test
     fun `a second attach is refused so one pane never holds two sessions`() = runTest {
         val first = WatchedSession()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionReconnectTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionReconnectTest.kt
@@ -4,8 +4,14 @@ package app.skerry.ui.connection
 
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshAuth
+import app.skerry.shared.ssh.SshConnection
 import app.skerry.shared.ssh.SshTarget
+import app.skerry.shared.ssh.SshTransport
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -17,6 +23,11 @@ import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 /**
  * Auto-reconnect after a drop: what the loop retries, when it gives up, and what it tells the
@@ -395,5 +406,247 @@ class ConnectionReconnectTest {
         assertEquals(1, conn1.roundTrips) // old loop stopped with the old session
         assertEquals(1, conn2.roundTrips) // new session pings immediately again
         scope.cancel()
+    }
+
+    /**
+     * A drop and the user closing the pane are handled by two different threads: the loss lands on
+     * the controller's scope, the click on the UI one. [ConnectionController.onSessionLost] read
+     * "still Connected" and then wrote [ConnectionUiState.Disconnected] without holding the lock
+     * [disconnect] writes [ConnectionUiState.Form] under, so a click that landed in between was
+     * undone — and [ConnectionController.connect] only ever starts from Form, so the pane could not
+     * be brought back at all, silently (issue #353: how the desktop toolbar test flaked on CI).
+     *
+     * Rounds rather than one attempt, because the window is the width of one teardown; the fix
+     * closes it, so a green run here is not luck.
+     */
+    @Test
+    fun `a drop racing an explicit disconnect leaves the form ready to connect`() {
+        // Real threads on purpose: with the loss handler and the disconnect serialized onto one
+        // dispatcher the Connected guard alone is enough, and the defect cannot be staged at all.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            repeat(RACE_ROUNDS) { round ->
+                val dropped = FakeShellChannel()
+                val transport = ScriptedTransport(
+                    listOf(
+                        Result.success(FakeSshConnection(dropped)),
+                        Result.success(FakeSshConnection(FakeShellChannel())),
+                    ),
+                )
+                val controller = ConnectionController(transport, scope, maxReconnectAttempts = 0)
+                controller.connect(testTarget, SshAuth.Password("pw"))
+                controller.awaitState<ConnectionUiState.Connected>("round $round: the first connect")
+
+                dropped.drop() // the transport drops — handled on the controller's scope
+                controller.disconnect() // ...while the user closes the pane
+
+                controller.holdState<ConnectionUiState.Form>("round $round: the closed pane")
+                controller.connect(testTarget, SshAuth.Password("pw"))
+                controller.awaitState<ConnectionUiState.Connected>("round $round: the connect after the drop")
+                controller.disconnect()
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /**
+     * The vault lock ends a mid-flight reconnect — the credentials it would use are gone, so no
+     * path can bring that session back. The attempt in flight has to end with it: past its last
+     * cancellation check it would otherwise publish a live session whose credentials were just
+     * wiped, on a pane the lock had already stood down. Staged through [newSessionScope], as above.
+     */
+    @Test
+    fun `a reconnect finishing after the vault locked leaves nothing open`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val dropped = FakeShellChannel()
+        val reconnected = FakeSshConnection(FakeShellChannel())
+        val reachedWindow = CompletableDeferred<Unit>()
+        val leaveWindow = CompletableDeferred<Unit>()
+        try {
+            var sessions = 0
+            val controller = ConnectionController(
+                ScriptedTransport(listOf(Result.success(FakeSshConnection(dropped)), Result.success(reconnected))),
+                scope,
+                newSessionScope = {
+                    // Only the reconnect's own handshake is held; the first connect must complete.
+                    if (sessions++ > 0) {
+                        reachedWindow.complete(Unit)
+                        while (!leaveWindow.isCompleted) Thread.sleep(1)
+                    }
+                    CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                },
+                maxReconnectAttempts = 3,
+                reconnectDelayMillis = { 0L },
+            )
+
+            controller.connect(testTarget, SshAuth.Password("pw"))
+            controller.awaitState<ConnectionUiState.Connected>("the first connect")
+            dropped.drop() // the transport drops → the reconnect attempt reaches the window
+            awaitTrue("the reconnect to reach the publication") { reachedWindow.isCompleted }
+
+            controller.clearReconnectCredentials() // the vault locks
+            leaveWindow.complete(Unit)
+
+            controller.holdState<ConnectionUiState.Disconnected>("the stood-down pane")
+            assertFalse(
+                (controller.uiState as ConnectionUiState.Disconnected).reconnecting,
+                "the pane must not claim it is reconnecting after the lock",
+            )
+            awaitTrue("the reconnected session to be released") { reconnected.disconnected }
+        } finally {
+            leaveWindow.complete(Unit)
+            scope.cancel()
+        }
+    }
+
+    /**
+     * The same defect on the connect side, staged rather than raced. Cancelling the connect job
+     * cannot stop a handshake that is already past its last `ensureActive` — everything from there
+     * to the transition is synchronous — so the pane the user has just closed came back Connected
+     * over a session whose teardown had already run, holding a connection nobody would ever close.
+     *
+     * [newSessionScope] is the hook: it is called inside exactly that window, so blocking in it
+     * puts the disconnect where the race would have put it, every run.
+     */
+    @Test
+    fun `a handshake finishing after the pane was closed leaves nothing open`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val connection = FakeSshConnection(FakeShellChannel())
+        val reachedWindow = CompletableDeferred<Unit>()
+        val leaveWindow = CompletableDeferred<Unit>()
+        try {
+            val controller = ConnectionController(
+                ScriptedTransport(listOf(Result.success(connection))),
+                scope,
+                newSessionScope = {
+                    reachedWindow.complete(Unit)
+                    while (!leaveWindow.isCompleted) Thread.sleep(1)
+                    CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                },
+                maxReconnectAttempts = 0,
+            )
+
+            controller.connect(testTarget, SshAuth.Password("pw"))
+            awaitTrue("the handshake to reach the publication") { reachedWindow.isCompleted }
+            controller.disconnect() // the user closes the pane; the handshake cannot be cancelled now
+            leaveWindow.complete(Unit)
+
+            controller.holdState<ConnectionUiState.Form>("the pane closed mid-handshake")
+            awaitTrue("the connection to be released") { connection.disconnected }
+        } finally {
+            leaveWindow.complete(Unit)
+            scope.cancel()
+        }
+    }
+
+    /**
+     * The tail of the retry loop is the same trap once more: nothing suspends between the last
+     * attempt's failure and the give-up write, so cancelling the job cannot stop it. It used to put
+     * [ConnectionUiState.Disconnected] — "reconnect failed" — over the [ConnectionUiState.Form] the
+     * user's close had already set, leaving the pane in the state [ConnectionController.connect]
+     * refuses to start from. The transport blocks without suspending, so the close lands exactly
+     * there on every run.
+     */
+    @Test
+    fun `a reconnect giving up after the pane was closed leaves the form alone`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val dropped = FakeShellChannel()
+        val reachedRetry = CompletableDeferred<Unit>()
+        val leaveRetry = CompletableDeferred<Unit>()
+        try {
+            val controller = ConnectionController(
+                GatedRetryTransport(FakeSshConnection(dropped), reachedRetry, leaveRetry),
+                scope,
+                maxReconnectAttempts = 1, // one attempt, so its failure is the verdict
+                reconnectDelayMillis = { 0L },
+            )
+
+            controller.connect(testTarget, SshAuth.Password("pw"))
+            controller.awaitState<ConnectionUiState.Connected>("the first connect")
+            dropped.drop() // the transport drops → the only retry starts and blocks
+            awaitTrue("the last reconnect attempt to start") { reachedRetry.isCompleted }
+
+            controller.disconnect() // the user closes the pane while that attempt is doomed but alive
+            leaveRetry.complete(Unit)
+
+            controller.holdState<ConnectionUiState.Form>("the pane closed during the last attempt")
+            // The hold alone would also pass on a runner slow enough that the stale write simply
+            // had not landed yet, so the verdict is what the user does next: connecting again must
+            // get through and stay through. A stale "reconnect failed" landing before this leaves a
+            // pane connect refuses to start from; landing after it, it overwrites a live session.
+            controller.connect(testTarget, SshAuth.Password("pw"))
+            controller.awaitState<ConnectionUiState.Connected>("the connect after the closed pane")
+            controller.holdState<ConnectionUiState.Connected>("the pane connected again")
+        } finally {
+            leaveRetry.complete(Unit)
+            scope.cancel()
+        }
+    }
+}
+
+/**
+ * Succeeds, then blocks the retry inside `connect` — without suspending, so cancelling the
+ * reconnect job cannot stop it — and fails that attempt when released. Every connect after it
+ * succeeds again, so a test can ask whether the pane still works afterwards.
+ */
+private class GatedRetryTransport(
+    private val first: SshConnection,
+    private val reachedRetry: CompletableDeferred<Unit>,
+    private val leaveRetry: CompletableDeferred<Unit>,
+) : SshTransport {
+    private var calls = 0
+
+    override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection {
+        when (calls++) {
+            0 -> return first
+            1 -> {
+                reachedRetry.complete(Unit)
+                while (!leaveRetry.isCompleted) Thread.sleep(1)
+                error("route to host lost")
+            }
+            else -> return FakeSshConnection(FakeShellChannel())
+        }
+    }
+}
+
+/**
+ * Rounds of the races above. The window is one teardown wide, so a handful of rounds already hits it
+ * on a loaded machine; this many keeps it honest on an idle one. Costs a few seconds per test.
+ */
+private const val RACE_ROUNDS = 200
+
+/** Spins until [uiState] is [T], naming what was waited for and what it actually holds. */
+private inline fun <reified T> ConnectionController.awaitState(what: String, timeout: Duration = 5.seconds) {
+    val deadline = TimeSource.Monotonic.markNow() + timeout
+    while (uiState !is T) {
+        if (deadline.hasPassedNow()) {
+            fail("$what never reached ${T::class.simpleName}: uiState=${uiState::class.simpleName}")
+        }
+        // Parks rather than spins: the work being waited for runs on a pool that a busy loop on
+        // a small CI runner would starve — the very condition these tests exist for.
+        Thread.sleep(1)
+    }
+}
+
+/** Spins until [condition] holds, naming what was waited for. */
+private fun awaitTrue(what: String, timeout: Duration = 5.seconds, condition: () -> Boolean) {
+    val deadline = TimeSource.Monotonic.markNow() + timeout
+    while (!condition()) {
+        if (deadline.hasPassedNow()) fail("$what never happened")
+        Thread.sleep(1)
+    }
+}
+
+/**
+ * Fails if [uiState] leaves [T] within [window]. The assertion has to be a held one: the handler
+ * that used to overwrite the state runs on another thread and may not have landed yet.
+ */
+private inline fun <reified T> ConnectionController.holdState(what: String, window: Duration = 10.milliseconds) {
+    val deadline = TimeSource.Monotonic.markNow() + window
+    while (!deadline.hasPassedNow()) {
+        val state = uiState
+        if (state !is T) fail("$what left ${T::class.simpleName} for ${state::class.simpleName}")
+        Thread.sleep(1)
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestFixtures.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestFixtures.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlin.concurrent.Volatile
 
 internal val testTarget = SshTarget(host = "h", port = 22, username = "u")
 
@@ -92,6 +93,9 @@ internal class FakeSshConnection(
     private val channel: ShellChannel,
     private val sftp: SftpClient? = null,
 ) : SshConnection {
+    // Written by the controller's teardown on one thread and read by the race tests' waits on
+    // another, with no lock between them: without this the read is free never to see the write.
+    @Volatile
     var disconnected = false
         private set
     var openSftpCalls = 0
@@ -151,7 +155,10 @@ internal class FakeShellChannel : ShellChannel {
     }
     override suspend fun resize(size: PtySize) {}
     /** Server/transport-side drop: the channel ends WITHOUT EOF (reconnect candidate). */
-    override suspend fun close() {
+    override suspend fun close() = drop()
+
+    /** [close] without the suspend, for the tests that drop a channel from outside a coroutine. */
+    fun drop() {
         emissions.close()
     }
 


### PR DESCRIPTION
Closing a pane while its session was dropping could leave that pane in a state it was unable to leave: the loss handler wrote `Disconnected` over the `Form` the close had just set, and a connect only ever starts from `Form`, so the pane stayed dead and its toolbar action never came back — with no error anywhere. Under CI load this is how `ToolbarDisabledActionsTest` timed out.

Every write to the connection state now happens under one lock together with the check that guards it, stamped with a session generation that each teardown retires, so a writer belonging to a session that is already gone writes nothing. Job cancellation cannot replace this: past its last cancellation check, a handshake or a retry attempt runs to the end whatever the job's state.

Two further defects of the same shape are fixed with it:

- a handshake finishing after the pane was closed published a live session over the form and left an SSH connection nobody would ever close;
- the auto-reconnect loop wrote the pane's state without a guard, including the "gave up" write that lands after the last attempt fails.

## Tests

- `a drop racing an explicit disconnect leaves the form ready to connect` — 200 rounds on real threads; the regression test for the issue.
- `a handshake finishing after the pane was closed leaves nothing open`, `a reconnect finishing after the vault locked leaves nothing open`, `a reconnect giving up after the pane was closed leaves the form alone` — deterministic, each staged inside the exact window its race lives in rather than raced.
- `an attach that loses the form leaves the winning session on the pane` — the refusal branch of a watched-session attach.

Each new test was verified red with the guard it covers reverted.

## How to verify

Connect to a host, drop the session from the server side (`pkill -f 'sshd:.*@pts'` on that host, or pull the network), and close the pane while it is dropping. The pane must return to the form and accept a new connection immediately. Repeat under load (`stress-ng -c $(nproc)`) — before this fix the pane went dead about one attempt in twenty there.

The scenario from the issue was also run 300 times in a throwaway desktop UI test: green both idle and under load, and red with the fix reverted — failing with the `ComposeTimeoutException` from the issue.

Not verified live: Android, a real server, other operating systems.

Fixes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
